### PR TITLE
refactor: modularize user service with argon2 security

### DIFF
--- a/backend/services/user_service/index.js
+++ b/backend/services/user_service/index.js
@@ -1,0 +1,30 @@
+import { UserApplication } from "./src/UserApplication.js";
+import { MongoClientInstance } from "../../common_scripts/mongo.js";
+
+const port = process.env.PORT || 4002;
+const application = new UserApplication({ port });
+
+let server;
+
+const start = async () => {
+  try {
+    server = await application.start();
+  } catch (error) {
+    console.error("Failed to start user service", error);
+    process.exit(1);
+  }
+};
+
+start();
+
+const shutdown = async (signal) => {
+  console.log(`Received ${signal}. Shutting down gracefully...`);
+  if (server) {
+    await new Promise((resolve) => server.close(resolve));
+  }
+  await MongoClientInstance.close();
+  process.exit(0);
+};
+
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));

--- a/backend/services/user_service/package.json
+++ b/backend/services/user_service/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "dev": "nodemon index.js",
+    "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -11,6 +13,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.17.1",
   "dependencies": {
+    "argon2": "^0.43.0",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "mongodb": "^6.20.0",

--- a/backend/services/user_service/src/UserApplication.js
+++ b/backend/services/user_service/src/UserApplication.js
@@ -1,0 +1,55 @@
+import express from "express";
+import { MongoClientInstance } from "../../../common_scripts/mongo.js";
+import { PasswordHasher } from "./security/PasswordHasher.js";
+import { UserRepository } from "./repositories/UserRepository.js";
+import { UserService } from "./services/UserService.js";
+import { UserController, errorMiddleware } from "./controllers/UserController.js";
+import { createUserRouter } from "./routes/userRoutes.js";
+import { enforceHttps } from "./middleware/enforceHttps.js";
+import { securityHeaders } from "./middleware/securityHeaders.js";
+
+export class UserApplication {
+  constructor({ port = process.env.PORT || 4002 } = {}) {
+    this.port = port;
+    this.app = null;
+  }
+
+  async init() {
+    if (this.app) {
+      return this.app;
+    }
+
+    await MongoClientInstance.start();
+    const repository = await UserRepository.initialize(MongoClientInstance.db);
+    const passwordHasher = new PasswordHasher();
+    const userService = new UserService({ repository, passwordHasher });
+    const controller = new UserController(userService);
+
+    const app = express();
+    app.enable("trust proxy");
+    app.use(express.json());
+    app.use(securityHeaders);
+    app.use(enforceHttps);
+
+    app.get("/status", (_req, res) => {
+      res.json({ status: "ok" });
+    });
+
+    app.use("/api/users", createUserRouter(controller));
+
+    app.use(errorMiddleware);
+
+    this.app = app;
+    return app;
+  }
+
+  async start() {
+    const app = await this.init();
+    return new Promise((resolve) => {
+      this.server = app.listen(this.port, () => {
+        console.log(`User service listening on port ${this.port}`);
+        resolve(this.server);
+      });
+    });
+  }
+}

--- a/backend/services/user_service/src/controllers/UserController.js
+++ b/backend/services/user_service/src/controllers/UserController.js
@@ -1,0 +1,91 @@
+import { ApiError } from "../errors/ApiError.js";
+
+export class UserController {
+  constructor(userService) {
+    this.userService = userService;
+  }
+
+  register = async (req, res, next) => {
+    try {
+      const user = await this.userService.registerUser(req.body ?? {});
+      res.status(201).json({ message: "User registered successfully.", user });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  login = async (req, res, next) => {
+    try {
+      const user = await this.userService.authenticateUser(req.body ?? {});
+      res.json({ message: "Login successful.", user });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getById = async (req, res, next) => {
+    try {
+      const user = await this.userService.getUserById(req.params.id);
+      res.json({ user });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  update = async (req, res, next) => {
+    try {
+      const user = await this.userService.updateUser(req.params.id, req.body ?? {});
+      res.json({ message: "User updated successfully.", user });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  delete = async (req, res, next) => {
+    try {
+      await this.userService.deleteUser(req.params.id, req.body?.password);
+      res.json({ message: "User deleted successfully." });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  requestPasswordReset = async (req, res, next) => {
+    try {
+      const result = await this.userService.requestPasswordReset(req.body?.email);
+      const responseBody = {
+        message: "If an account exists for that email, a password reset link has been issued.",
+      };
+      if (result && process.env.NODE_ENV !== "production") {
+        responseBody.resetToken = result.resetToken;
+        responseBody.expiresAt = result.expiresAt;
+      }
+      res.json(responseBody);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  resetPassword = async (req, res, next) => {
+    try {
+      const user = await this.userService.resetPassword(req.body?.token, req.body?.password);
+      res.json({ message: "Password reset successfully.", user });
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+export const errorMiddleware = (err, req, res, _next) => {
+  if (err instanceof ApiError) {
+    const payload = { message: err.message };
+    if (Array.isArray(err.details)) {
+      payload.errors = err.details;
+    }
+    res.status(err.status).json(payload);
+    return;
+  }
+
+  console.error(err);
+  res.status(500).json({ message: "An unexpected error occurred." });
+};

--- a/backend/services/user_service/src/errors/ApiError.js
+++ b/backend/services/user_service/src/errors/ApiError.js
@@ -1,0 +1,7 @@
+export class ApiError extends Error {
+  constructor(status, message, details = undefined) {
+    super(message);
+    this.status = status;
+    this.details = details;
+  }
+}

--- a/backend/services/user_service/src/middleware/enforceHttps.js
+++ b/backend/services/user_service/src/middleware/enforceHttps.js
@@ -1,0 +1,10 @@
+export const enforceHttps = (req, res, next) => {
+  if (process.env.NODE_ENV === "production") {
+    const forwardedProto = req.get("x-forwarded-proto");
+    const isSecure = req.secure || forwardedProto === "https";
+    if (!isSecure) {
+      return res.status(400).json({ message: "HTTPS is required." });
+    }
+  }
+  next();
+};

--- a/backend/services/user_service/src/middleware/securityHeaders.js
+++ b/backend/services/user_service/src/middleware/securityHeaders.js
@@ -1,0 +1,4 @@
+export const securityHeaders = (req, res, next) => {
+  res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  next();
+};

--- a/backend/services/user_service/src/repositories/UserRepository.js
+++ b/backend/services/user_service/src/repositories/UserRepository.js
@@ -1,0 +1,104 @@
+import { ObjectId } from "mongodb";
+
+export class UserRepository {
+  constructor(db) {
+    this.collection = db.collection("users");
+  }
+
+  static async initialize(db) {
+    const repository = new UserRepository(db);
+    await repository.ensureIndexes();
+    return repository;
+  }
+
+  async ensureIndexes() {
+    await Promise.all([
+      this.collection.createIndex({ email: 1 }, { unique: true, name: "uniq_email" }),
+      this.collection.createIndex({ username: 1 }, { unique: true, name: "uniq_username" }),
+    ]);
+  }
+
+  async create(user) {
+    const now = new Date();
+    const payload = {
+      ...user,
+      createdAt: now,
+      updatedAt: now,
+      failedLoginAttempts: 0,
+      failedLoginWindowStart: null,
+      accountLocked: false,
+      accountLockedAt: null,
+    };
+    const result = await this.collection.insertOne(payload);
+    return { ...payload, _id: result.insertedId };
+  }
+
+  async findByEmail(email) {
+    return this.collection.findOne({ email });
+  }
+
+  async findByUsername(username) {
+    return this.collection.findOne({ username });
+  }
+
+  async findByEmailOrUsername(email, username) {
+    return this.collection.findOne({
+      $or: [{ email }, { username }],
+    });
+  }
+
+  async findById(id) {
+    if (!ObjectId.isValid(id)) {
+      return null;
+    }
+    return this.collection.findOne({ _id: new ObjectId(id) });
+  }
+
+  async findByResetToken(hashedToken) {
+    return this.collection.findOne({
+      passwordResetToken: hashedToken,
+      passwordResetExpiresAt: { $gt: new Date() },
+    });
+  }
+
+  async updateById(id, { set = {}, unset = {} }) {
+    if (!ObjectId.isValid(id)) {
+      return null;
+    }
+    const update = {};
+    const updatedAt = new Date();
+    update.$set = { updatedAt, ...set };
+    if (Object.keys(unset).length > 0) {
+      update.$unset = unset;
+    }
+
+    const result = await this.collection.findOneAndUpdate(
+      { _id: new ObjectId(id) },
+      update,
+      { returnDocument: "after" },
+    );
+    return result.value;
+  }
+
+  async updateOne(filter, { set = {}, unset = {} }) {
+    const update = {};
+    const updatedAt = new Date();
+    update.$set = { updatedAt, ...set };
+    if (Object.keys(unset).length > 0) {
+      update.$unset = unset;
+    }
+
+    const result = await this.collection.findOneAndUpdate(filter, update, {
+      returnDocument: "after",
+    });
+    return result.value;
+  }
+
+  async deleteById(id) {
+    if (!ObjectId.isValid(id)) {
+      return false;
+    }
+    const result = await this.collection.deleteOne({ _id: new ObjectId(id) });
+    return result.deletedCount === 1;
+  }
+}

--- a/backend/services/user_service/src/routes/userRoutes.js
+++ b/backend/services/user_service/src/routes/userRoutes.js
@@ -1,0 +1,15 @@
+import { Router } from "express";
+
+export const createUserRouter = (controller) => {
+  const router = Router();
+
+  router.post("/register", controller.register);
+  router.post("/login", controller.login);
+  router.get("/:id", controller.getById);
+  router.patch("/:id", controller.update);
+  router.delete("/:id", controller.delete);
+  router.post("/password-reset/request", controller.requestPasswordReset);
+  router.post("/password-reset/confirm", controller.resetPassword);
+
+  return router;
+};

--- a/backend/services/user_service/src/security/LoginSecurityManager.js
+++ b/backend/services/user_service/src/security/LoginSecurityManager.js
@@ -1,0 +1,52 @@
+export class LoginSecurityManager {
+  static MAX_FAILED_ATTEMPTS = 5;
+  static FAILURE_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
+
+  static isAccountLocked(user) {
+    return Boolean(user?.accountLocked);
+  }
+
+  static getLockMessage() {
+    return "Account locked due to multiple failed login attempts. Please reset your password to unlock.";
+  }
+
+  static buildFailedAttemptUpdate(user) {
+    const now = new Date();
+    const priorWindowStart = user?.failedLoginWindowStart
+      ? new Date(user.failedLoginWindowStart)
+      : null;
+
+    let failedAttempts = (user?.failedLoginAttempts ?? 0) + 1;
+    let windowStart = priorWindowStart ?? now;
+
+    if (!priorWindowStart || now.getTime() - priorWindowStart.getTime() > this.FAILURE_WINDOW_MS) {
+      failedAttempts = 1;
+      windowStart = now;
+    }
+
+    const update = {
+      failedLoginAttempts: failedAttempts,
+      failedLoginWindowStart: windowStart,
+    };
+
+    if (failedAttempts >= this.MAX_FAILED_ATTEMPTS) {
+      update.accountLocked = true;
+      update.accountLockedAt = now;
+    }
+
+    return update;
+  }
+
+  static buildSuccessfulLoginUpdate() {
+    return {
+      failedLoginAttempts: 0,
+      failedLoginWindowStart: null,
+      accountLocked: false,
+      accountLockedAt: null,
+    };
+  }
+
+  static buildUnlockUpdate() {
+    return this.buildSuccessfulLoginUpdate();
+  }
+}

--- a/backend/services/user_service/src/security/PasswordHasher.js
+++ b/backend/services/user_service/src/security/PasswordHasher.js
@@ -1,0 +1,25 @@
+import argon2 from "argon2";
+
+export class PasswordHasher {
+  constructor(options = {}) {
+    this.options = {
+      type: argon2.argon2id,
+      memoryCost: 2 ** 16,
+      timeCost: 3,
+      parallelism: 1,
+      ...options,
+    };
+  }
+
+  async hash(password) {
+    return argon2.hash(password, this.options);
+  }
+
+  async verify(hash, password) {
+    try {
+      return await argon2.verify(hash, password, this.options);
+    } catch (error) {
+      return false;
+    }
+  }
+}

--- a/backend/services/user_service/src/services/UserService.js
+++ b/backend/services/user_service/src/services/UserService.js
@@ -1,0 +1,220 @@
+import crypto from "crypto";
+import { ApiError } from "../errors/ApiError.js";
+import { UserValidator } from "../validators/UserValidator.js";
+import { LoginSecurityManager } from "../security/LoginSecurityManager.js";
+
+export class UserService {
+  constructor({ repository, passwordHasher }) {
+    this.repository = repository;
+    this.passwordHasher = passwordHasher;
+  }
+
+  sanitizeUser(user) {
+    if (!user) return null;
+    const {
+      _id,
+      passwordHash,
+      passwordResetToken,
+      passwordResetExpiresAt,
+      failedLoginAttempts,
+      failedLoginWindowStart,
+      accountLocked,
+      accountLockedAt,
+      ...rest
+    } = user;
+    return {
+      id: _id.toString(),
+      ...rest,
+    };
+  }
+
+  async registerUser(payload) {
+    const { errors, normalized } = UserValidator.validateRegistration(payload);
+    if (errors.length > 0) {
+      throw new ApiError(400, "Validation failed.", errors);
+    }
+
+    const existing = await this.repository.findByEmailOrUsername(
+      normalized.email,
+      normalized.username,
+    );
+    if (existing) {
+      const conflicts = [];
+      if (existing.email === normalized.email) conflicts.push("email");
+      if (existing.username === normalized.username) conflicts.push("username");
+      throw new ApiError(
+        409,
+        `The following fields are already taken: ${conflicts.join(", ")}.`,
+      );
+    }
+
+    const passwordHash = await this.passwordHasher.hash(normalized.password);
+    const createdUser = await this.repository.create({
+      username: normalized.username,
+      email: normalized.email,
+      passwordHash,
+    });
+
+    return this.sanitizeUser(createdUser);
+  }
+
+  async authenticateUser(payload) {
+    const { errors, normalized } = UserValidator.validateLogin(payload);
+    if (errors.length > 0) {
+      throw new ApiError(400, "Validation failed.", errors);
+    }
+
+    const user = await this.repository.findByEmail(normalized.email);
+    if (!user) {
+      throw new ApiError(401, "Invalid email or password.");
+    }
+
+    if (LoginSecurityManager.isAccountLocked(user)) {
+      throw new ApiError(423, LoginSecurityManager.getLockMessage());
+    }
+
+    const passwordMatches = await this.passwordHasher.verify(
+      user.passwordHash,
+      normalized.password,
+    );
+
+    if (!passwordMatches) {
+      const update = LoginSecurityManager.buildFailedAttemptUpdate(user);
+      await this.repository.updateById(user._id, { set: update });
+      throw new ApiError(401, "Invalid email or password.");
+    }
+
+    const securityReset = LoginSecurityManager.buildSuccessfulLoginUpdate();
+    const updatedUser = await this.repository.updateById(user._id, { set: securityReset });
+    return this.sanitizeUser(updatedUser ?? user);
+  }
+
+  async getUserById(id) {
+    const user = await this.repository.findById(id);
+    if (!user) {
+      throw new ApiError(404, "User not found.");
+    }
+    return this.sanitizeUser(user);
+  }
+
+  async updateUser(id, updates) {
+    const { errors, sanitizedUpdates } = UserValidator.validateUpdate(updates);
+    if (errors.length > 0) {
+      throw new ApiError(400, "Validation failed.", errors);
+    }
+
+    const currentUser = await this.repository.findById(id);
+    if (!currentUser) {
+      throw new ApiError(404, "User not found.");
+    }
+
+    if (
+      sanitizedUpdates.email &&
+      sanitizedUpdates.email !== currentUser.email
+    ) {
+      const existing = await this.repository.findByEmail(sanitizedUpdates.email);
+      if (existing && existing._id.toString() !== currentUser._id.toString()) {
+        throw new ApiError(409, "Email is already taken.");
+      }
+    }
+
+    if (
+      sanitizedUpdates.username &&
+      sanitizedUpdates.username !== currentUser.username
+    ) {
+      const existing = await this.repository.findByUsername(sanitizedUpdates.username);
+      if (existing && existing._id.toString() !== currentUser._id.toString()) {
+        throw new ApiError(409, "Username is already taken.");
+      }
+    }
+
+    const updatePayload = { ...sanitizedUpdates };
+    if (sanitizedUpdates.password) {
+      updatePayload.passwordHash = await this.passwordHasher.hash(sanitizedUpdates.password);
+      delete updatePayload.password;
+    }
+
+    const updatedUser = await this.repository.updateById(id, { set: updatePayload });
+    if (!updatedUser) {
+      throw new ApiError(404, "User not found.");
+    }
+    return this.sanitizeUser(updatedUser);
+  }
+
+  async deleteUser(id, password) {
+    const user = await this.repository.findById(id);
+    if (!user) {
+      throw new ApiError(404, "User not found.");
+    }
+
+    if (typeof password !== "string" || password.length === 0) {
+      throw new ApiError(400, "Password confirmation is required.");
+    }
+
+    const passwordMatches = await this.passwordHasher.verify(user.passwordHash, password);
+    if (!passwordMatches) {
+      throw new ApiError(401, "Invalid password.");
+    }
+
+    const deleted = await this.repository.deleteById(id);
+    if (!deleted) {
+      throw new ApiError(500, "Failed to delete user.");
+    }
+  }
+
+  async requestPasswordReset(email) {
+    const normalizedEmail = UserValidator.normalizeEmail(email);
+    if (!normalizedEmail || !UserValidator.emailRegex.test(normalizedEmail)) {
+      throw new ApiError(400, "A valid email address is required.");
+    }
+
+    const user = await this.repository.findByEmail(normalizedEmail);
+    if (!user) {
+      return; // Avoid account enumeration
+    }
+
+    const resetToken = crypto.randomBytes(32).toString("hex");
+    const hashedToken = crypto.createHash("sha256").update(resetToken).digest("hex");
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+
+    await this.repository.updateById(user._id, {
+      set: {
+        passwordResetToken: hashedToken,
+        passwordResetExpiresAt: expiresAt,
+      },
+    });
+
+    return { resetToken, expiresAt };
+  }
+
+  async resetPassword(token, newPassword) {
+    if (typeof token !== "string" || token.trim().length === 0) {
+      throw new ApiError(400, "Password reset token is required.");
+    }
+
+    if (!UserValidator.isValidPassword(newPassword)) {
+      throw new ApiError(400, "Password does not meet complexity requirements.");
+    }
+
+    const hashedToken = crypto.createHash("sha256").update(token).digest("hex");
+    const user = await this.repository.findByResetToken(hashedToken);
+    if (!user) {
+      throw new ApiError(400, "Invalid or expired password reset token.");
+    }
+
+    const passwordHash = await this.passwordHasher.hash(newPassword);
+    const unlockFields = LoginSecurityManager.buildUnlockUpdate();
+    const updatedUser = await this.repository.updateById(user._id, {
+      set: {
+        passwordHash,
+        ...unlockFields,
+      },
+      unset: {
+        passwordResetToken: "",
+        passwordResetExpiresAt: "",
+      },
+    });
+
+    return this.sanitizeUser(updatedUser ?? user);
+  }
+}

--- a/backend/services/user_service/src/validators/UserValidator.js
+++ b/backend/services/user_service/src/validators/UserValidator.js
@@ -1,0 +1,104 @@
+export class UserValidator {
+  static emailRegex = /^(?:[\w.!#$%&'*+/=?^`{|}~-]+)@(?:[\w-]+\.)+[\w-]{2,}$/i;
+  static usernameRegex = /^[A-Za-z0-9_]{3,30}$/;
+  static passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+
+  static normalizeEmail(email) {
+    return typeof email === "string" ? email.trim().toLowerCase() : "";
+  }
+
+  static normalizeUsername(username) {
+    return typeof username === "string" ? username.trim() : "";
+  }
+
+  static validateRegistration({ username, email, password }) {
+    const errors = [];
+    const normalizedUsername = this.normalizeUsername(username);
+    const normalizedEmail = this.normalizeEmail(email);
+
+    if (!normalizedUsername || !this.usernameRegex.test(normalizedUsername)) {
+      errors.push(
+        "Username must be 3-30 characters long and contain only letters, numbers, or underscores.",
+      );
+    }
+
+    if (!normalizedEmail || !this.emailRegex.test(normalizedEmail)) {
+      errors.push("A valid email address is required.");
+    }
+
+    if (!this.isValidPassword(password)) {
+      errors.push(
+        "Password must be at least 8 characters long and include 1 uppercase letter, 1 number, and 1 special character.",
+      );
+    }
+
+    return {
+      errors,
+      normalized: {
+        username: normalizedUsername,
+        email: normalizedEmail,
+        password,
+      },
+    };
+  }
+
+  static validateLogin({ email, password }) {
+    const errors = [];
+    const normalizedEmail = this.normalizeEmail(email);
+
+    if (!normalizedEmail || !this.emailRegex.test(normalizedEmail)) {
+      errors.push("A valid email address is required.");
+    }
+
+    if (typeof password !== "string" || password.length === 0) {
+      errors.push("Password is required.");
+    }
+
+    return { errors, normalized: { email: normalizedEmail, password } };
+  }
+
+  static validateUpdate(updates) {
+    const errors = [];
+    const sanitizedUpdates = {};
+
+    if (Object.hasOwn(updates, "email")) {
+      const normalizedEmail = this.normalizeEmail(updates.email);
+      if (!normalizedEmail || !this.emailRegex.test(normalizedEmail)) {
+        errors.push("A valid email address is required.");
+      } else {
+        sanitizedUpdates.email = normalizedEmail;
+      }
+    }
+
+    if (Object.hasOwn(updates, "username")) {
+      const normalizedUsername = this.normalizeUsername(updates.username);
+      if (!normalizedUsername || !this.usernameRegex.test(normalizedUsername)) {
+        errors.push(
+          "Username must be 3-30 characters long and contain only letters, numbers, or underscores.",
+        );
+      } else {
+        sanitizedUpdates.username = normalizedUsername;
+      }
+    }
+
+    if (Object.hasOwn(updates, "password")) {
+      if (!this.isValidPassword(updates.password)) {
+        errors.push(
+          "Password must be at least 8 characters long and include 1 uppercase letter, 1 number, and 1 special character.",
+        );
+      } else {
+        sanitizedUpdates.password = updates.password;
+      }
+    }
+
+    if (Object.keys(sanitizedUpdates).length === 0) {
+      errors.push("At least one updatable field (email, username, password) must be provided.");
+    }
+
+    return { errors, sanitizedUpdates };
+  }
+
+  static isValidPassword(password) {
+    return typeof password === "string" && this.passwordRegex.test(password);
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the user service into layered modules with controllers, services, repositories, and shared error handling
- enforce TLS-only requests in production, set HSTS headers, and add Argon2-based password hashing with account lockout and reset flows
- expose dedicated routes for registration, login, CRUD, and password reset while sanitizing responses

## Testing
- node --check backend/services/user_service/index.js

------
https://chatgpt.com/codex/tasks/task_e_68d6369c4cc0833187f39a2f5bf58ae6