### PR TITLE
docs: document user service

### DIFF
--- a/backend/services/user_service/README.md
+++ b/backend/services/user_service/README.md
@@ -1,0 +1,55 @@
+# User Service
+
+## Overview
+The User Service is an Express-based microservice that manages account registration, authentication, profile maintenance, deletion, and password resets for PeerPrep. It boots through `UserApplication`, which wires shared MongoDB connectivity, configures security middleware, exposes a `/status` health check, and mounts the REST API under `/api/users`. 【F:backend/services/user_service/src/UserApplication.js†L1-L43】
+
+## Key capabilities
+- **Account lifecycle** – create, fetch, update, and delete users, with Argon2id hashing to protect stored credentials. 【F:backend/services/user_service/src/services/UserService.js†L8-L120】【F:backend/services/user_service/src/security/PasswordHasher.js†L1-L24】
+- **Authentication safety** – throttles repeated failures and automatically locks compromised accounts using the `LoginSecurityManager`. 【F:backend/services/user_service/src/services/UserService.js†L52-L105】【F:backend/services/user_service/src/security/LoginSecurityManager.js†L1-L45】
+- **Password recovery** – issues short-lived reset tokens and unlocks accounts upon successful resets. 【F:backend/services/user_service/src/services/UserService.js†L121-L198】
+- **Transport protections** – enforces HSTS headers everywhere and requires HTTPS in production deployments. 【F:backend/services/user_service/src/middleware/securityHeaders.js†L1-L5】【F:backend/services/user_service/src/middleware/enforceHttps.js†L1-L11】
+
+## API surface
+All endpoints are prefixed with `/api/users` via the service router. 【F:backend/services/user_service/src/routes/userRoutes.js†L1-L15】
+
+| Method & Path | Description |
+| --- | --- |
+| `POST /register` | Register a new user after validating username, email, and password strength. |
+| `POST /login` | Authenticate with email and password; locks the account after repeated failures. |
+| `GET /:id` | Retrieve a sanitized user profile by ID. |
+| `PATCH /:id` | Update email, username, or password (rehashed automatically). |
+| `DELETE /:id` | Remove the account after confirming the password. |
+| `POST /password-reset/request` | Request a password reset; returns the token only outside production. |
+| `POST /password-reset/confirm` | Reset the password with a valid token and unlock the account. |
+| `GET /status` | Health probe exposed at the root of the service. |
+
+## Architecture
+- **Controller layer** – translates HTTP requests into service calls, standardizes success payloads, and funnels errors through a shared middleware. 【F:backend/services/user_service/src/controllers/UserController.js†L1-L86】
+- **Service layer** – houses business rules for validation, uniqueness checks, credential hashing, login lockouts, and reset workflows. 【F:backend/services/user_service/src/services/UserService.js†L8-L198】
+- **Repository layer** – wraps the `users` MongoDB collection with helpers for CRUD operations, unique indexes, and reset-token lookups. 【F:backend/services/user_service/src/repositories/UserRepository.js†L1-L89】
+- **Validation & security utilities** – reusable validators and hashing/lockout helpers guarantee consistent input normalization and security posture. 【F:backend/services/user_service/src/validators/UserValidator.js†L1-L86】【F:backend/services/user_service/src/security/PasswordHasher.js†L1-L24】【F:backend/services/user_service/src/security/LoginSecurityManager.js†L1-L45】
+
+## Configuration
+The service reads the MongoDB database name from `backend/.env`, which you can scaffold from the template. 【F:backend/.env.example†L1-L1】
+
+```bash
+cd backend
+cp .env.example .env
+```
+
+## Running locally
+1. Install dependencies with pnpm (the repo uses pnpm workspaces). 【F:backend/services/user_service/package.json†L1-L24】
+   ```bash
+   cd backend
+   pnpm -r install
+   ```
+2. Ensure a MongoDB instance is reachable at `mongodb://localhost:27017` and that `MONGO_DB_NAME` in `.env` points to the desired database. 【F:backend/common_scripts/mongo.js†L1-L43】
+3. Start just the User Service:
+   ```bash
+   cd services/user_service
+   pnpm run dev
+   ```
+   This runs `nodemon index.js`, which boots the service on port `4002` by default. 【F:backend/services/user_service/package.json†L5-L18】【F:backend/services/user_service/index.js†L1-L26】
+
+## Error handling
+Domain failures throw `ApiError` instances that encode status codes and optional details. The controller’s error middleware converts them into JSON responses, while unexpected errors return a generic 500 payload. 【F:backend/services/user_service/src/controllers/UserController.js†L1-L86】


### PR DESCRIPTION
## Summary
- add a comprehensive README for the user service covering capabilities, endpoints, and architecture
- document local setup requirements, configuration, and error handling behaviour

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d644485a9083319e710af50ae7fc6a