### PR TITLE
feat(collaboration): scaffold realtime session management

### DIFF
--- a/backend/services/collaboration_service/README.md
+++ b/backend/services/collaboration_service/README.md
@@ -1,0 +1,64 @@
+# Collaboration Service
+
+The collaboration service exposes the backend capabilities that power PeerPrep's
+real-time pair programming experience. It offers REST endpoints for
+session lifecycle management and a Socket.IO gateway that synchronises the
+shared code editor between two matched users.
+
+## Getting started
+
+```
+pnpm install
+pnpm dev
+```
+
+The service listens on the port defined by `COLLABORATION_SERVICE_PORT` (defaults
+to `4004`).
+
+### Environment variables
+
+| Variable | Description |
+| --- | --- |
+| `COLLABORATION_SERVICE_PORT` | Port for the HTTP and WebSocket server. |
+| `COLLABORATION_CORS_ORIGIN` | Comma separated list of origins that are allowed to connect to the service. |
+
+## REST API
+
+`GET /status`
+: Health check endpoint.
+
+`POST /sessions`
+: Creates (or returns) an in-memory collaboration session. Payload accepts
+`sessionId`, optional `initialCode`, and optional `question` metadata.
+
+`GET /sessions/:sessionId`
+: Fetches the current snapshot for a session.
+
+`POST /sessions/:sessionId/question`
+: Updates the active question for the session and notifies connected clients.
+
+## Socket events
+
+All events expect the client to supply the `sessionId` that they are connected
+with. The server stores the latest session state and will broadcast relevant
+updates to the counterpart in the room.
+
+`session:join`
+: `{ sessionId, userId, displayName? }` → responds with the full session
+snapshot and notifies the other participant that a user has joined.
+
+`editor:change`
+: `{ sessionId, userId, fullText, clientVersion?, changeId? }` → updates the
+shared document and broadcasts the new revision to the other participant. The
+server applies optimistic concurrency and emits `editor:conflict` if an update
+is accepted while overwriting a newer revision (last-write-wins).
+
+`cursor:update`
+: `{ sessionId, userId, cursor }` → keeps peer cursors in sync.
+
+`session:leave`
+: `{ sessionId, userId }` → marks the user as disconnected and leaves the room.
+
+`session:user-disconnected`
+: Broadcast from the server when a socket disconnects unexpectedly so that the
+remaining participant can react (e.g. start a reconnection grace period).

--- a/backend/services/collaboration_service/index.js
+++ b/backend/services/collaboration_service/index.js
@@ -1,13 +1,28 @@
-import express from "express";
+import { createServer } from "http";
+import { Server } from "socket.io";
+import config from "./src/config.js";
+import createApp from "./src/app.js";
+import { sessionStore } from "./src/store/sessionStore.js";
+import { registerCollaborationHandlers } from "./src/socketHandlers.js";
 
-const port = process.env.COLLABORATIONSERVICEPORT || 4004;
-
-const app = express();
-
-app.get("/status", (req, res) => {
-  res.send("Collaboration service is up and running!");
+const app = createApp({
+  sessionStore,
+  corsOrigins: config.corsOrigins,
 });
 
-app.listen(port, () => {
-  console.log(`Collaboration service is running on port ${port}`);
+const server = createServer(app);
+
+const io = new Server(server, {
+  cors: {
+    origin: config.corsOrigins,
+    credentials: true,
+  },
+});
+
+app.set("io", io);
+
+registerCollaborationHandlers(io, { store: sessionStore });
+
+server.listen(config.port, () => {
+  console.log(`Collaboration service is running on port ${config.port}`);
 });

--- a/backend/services/collaboration_service/package.json
+++ b/backend/services/collaboration_service/package.json
@@ -11,11 +11,13 @@
   "license": "ISC",
   "packageManager": "pnpm@10.17.1",
   "dependencies": {
+    "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "express-jsdoc-swagger": "^1.8.0",
     "mongodb": "^6.20.0",
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "socket.io": "^4.8.1"
   },
   "type": "module"
 }

--- a/backend/services/collaboration_service/src/app.js
+++ b/backend/services/collaboration_service/src/app.js
@@ -1,0 +1,32 @@
+import cors from "cors";
+import express from "express";
+import buildSessionRouter from "./routes/sessionRoutes.js";
+
+const createApp = ({ sessionStore, corsOrigins }) => {
+  const app = express();
+
+  const corsOptions = {
+    origin: corsOrigins && corsOrigins.length > 0 ? corsOrigins : ["*"],
+    credentials: true,
+  };
+
+  app.use(cors(corsOptions));
+  app.use(express.json({ limit: "256kb" }));
+
+  app.get("/status", (req, res) => {
+    res.send("Collaboration service is up and running!");
+  });
+
+  app.use("/sessions", buildSessionRouter({ sessionStore }));
+
+  app.use((err, req, res, _next) => {
+    console.error("Unhandled error in collaboration service", err);
+    res.status(err.status ?? 500).json({
+      error: err.message ?? "Internal server error",
+    });
+  });
+
+  return app;
+};
+
+export default createApp;

--- a/backend/services/collaboration_service/src/config.js
+++ b/backend/services/collaboration_service/src/config.js
@@ -1,0 +1,41 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const DEFAULT_PORT = 4004;
+
+const parsePort = (rawPort) => {
+  if (!rawPort) {
+    return DEFAULT_PORT;
+  }
+
+  const parsed = Number.parseInt(rawPort, 10);
+
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return DEFAULT_PORT;
+  }
+
+  return parsed;
+};
+
+const parseCorsOrigins = (rawOrigins) => {
+  if (!rawOrigins || rawOrigins.trim() === "") {
+    return ["*"];
+  }
+
+  return rawOrigins
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+};
+
+export const config = {
+  port: parsePort(
+    process.env.COLLABORATION_SERVICE_PORT ||
+      process.env.COLLABORATIONSERVICEPORT ||
+      process.env.PORT
+  ),
+  corsOrigins: parseCorsOrigins(process.env.COLLABORATION_CORS_ORIGIN || ""),
+};
+
+export default config;

--- a/backend/services/collaboration_service/src/routes/sessionRoutes.js
+++ b/backend/services/collaboration_service/src/routes/sessionRoutes.js
@@ -1,0 +1,71 @@
+import { Router } from "express";
+
+const buildSessionRouter = ({ sessionStore }) => {
+  if (!sessionStore) {
+    throw new Error("A session store instance must be provided");
+  }
+
+  const router = Router();
+
+  router.post("/", (req, res) => {
+    const { sessionId, initialCode, question } = req.body ?? {};
+
+    if (!sessionId) {
+      return res.status(400).json({
+        error: "sessionId is required",
+      });
+    }
+
+    const { created } = sessionStore.ensureSession(sessionId, {
+      initialCode,
+      question,
+    });
+
+    const snapshot = sessionStore.getSessionSnapshot(sessionId);
+
+    return res.status(created ? 201 : 200).json({
+      session: snapshot,
+      created,
+    });
+  });
+
+  router.get("/:sessionId", (req, res) => {
+    const { sessionId } = req.params;
+    const snapshot = sessionStore.getSessionSnapshot(sessionId);
+
+    if (!snapshot) {
+      return res.status(404).json({
+        error: "Session not found",
+      });
+    }
+
+    return res.json({ session: snapshot });
+  });
+
+  router.post("/:sessionId/question", (req, res) => {
+    const { sessionId } = req.params;
+    const { question, userId } = req.body ?? {};
+
+    if (!question) {
+      return res.status(400).json({
+        error: "question payload is required",
+      });
+    }
+
+    const snapshot = sessionStore.setQuestion(sessionId, question, { userId });
+    const io = req.app.get("io");
+
+    if (io) {
+      io.to(sessionId).emit("question:updated", {
+        question: snapshot.question,
+        updatedBy: userId ?? null,
+      });
+    }
+
+    return res.status(200).json({ session: snapshot });
+  });
+
+  return router;
+};
+
+export default buildSessionRouter;

--- a/backend/services/collaboration_service/src/socketHandlers.js
+++ b/backend/services/collaboration_service/src/socketHandlers.js
@@ -1,0 +1,215 @@
+import { sessionStore } from "./store/sessionStore.js";
+
+const safeAck = (ack, payload) => {
+  if (typeof ack === "function") {
+    ack(payload);
+  }
+};
+
+const resolveSessionAndUser = (socket, payload) => {
+  const sessionId = payload?.sessionId ?? socket.data.sessionId;
+  const userId = payload?.userId ?? socket.data.userId;
+
+  return { sessionId, userId };
+};
+
+export const registerCollaborationHandlers = (io, { store = sessionStore } = {}) => {
+  io.on("connection", (socket) => {
+    socket.on("session:join", (payload, ack) => {
+      try {
+        const { sessionId, userId, displayName } = payload ?? {};
+
+        if (!sessionId || !userId) {
+          safeAck(ack, {
+            ok: false,
+            error: "sessionId and userId are required",
+          });
+          return;
+        }
+
+        const { participant, isNewParticipant } = store.addOrUpdateParticipant(
+          sessionId,
+          {
+            userId,
+            displayName,
+            socketId: socket.id,
+          }
+        );
+
+        socket.join(sessionId);
+        socket.data.sessionId = sessionId;
+        socket.data.userId = userId;
+
+        const snapshot = store.getSessionSnapshot(sessionId);
+
+        safeAck(ack, {
+          ok: true,
+          session: snapshot,
+        });
+
+        socket.emit("session:state", snapshot);
+
+        socket.to(sessionId).emit("session:user-joined", {
+          user: participant,
+          sessionId,
+          isNewParticipant,
+        });
+      } catch (error) {
+        console.error("Failed to join session", error);
+        safeAck(ack, {
+          ok: false,
+          error: error.message,
+        });
+      }
+    });
+
+    socket.on("editor:change", (payload, ack) => {
+      try {
+        const { sessionId, userId } = resolveSessionAndUser(socket, payload);
+        const { fullText, clientVersion, changeId } = payload ?? {};
+
+        if (!sessionId || !userId) {
+          safeAck(ack, {
+            ok: false,
+            error: "sessionId and userId are required",
+          });
+          return;
+        }
+
+        if (typeof fullText !== "string") {
+          safeAck(ack, {
+            ok: false,
+            error: "fullText must be provided as a string",
+          });
+          return;
+        }
+
+        const { conflict, version, lastChange } = store.applyCodeUpdate(sessionId, {
+          userId,
+          fullText,
+          clientVersion,
+          changeId,
+        });
+
+        const updatePayload = {
+          sessionId,
+          userId,
+          fullText,
+          version,
+          changeId: changeId ?? lastChange?.changeId ?? null,
+          conflict,
+        };
+
+        socket.to(sessionId).emit("editor:change", updatePayload);
+
+        if (conflict) {
+          io.to(sessionId).emit("editor:conflict", {
+            sessionId,
+            userId,
+            version,
+            changeId: updatePayload.changeId,
+          });
+        }
+
+        safeAck(ack, {
+          ok: true,
+          version,
+          conflict,
+        });
+      } catch (error) {
+        console.error("Failed to apply code update", error);
+        safeAck(ack, {
+          ok: false,
+          error: error.message,
+        });
+      }
+    });
+
+    socket.on("cursor:update", (payload, ack) => {
+      try {
+        const { sessionId, userId } = resolveSessionAndUser(socket, payload);
+        const { cursor } = payload ?? {};
+
+        if (!sessionId || !userId) {
+          safeAck(ack, {
+            ok: false,
+            error: "sessionId and userId are required",
+          });
+          return;
+        }
+
+        const participant = store.updateParticipantCursor(sessionId, userId, cursor);
+
+        if (!participant) {
+          safeAck(ack, {
+            ok: false,
+            error: "Participant not found in session",
+          });
+          return;
+        }
+
+        socket.to(sessionId).emit("cursor:update", {
+          sessionId,
+          userId,
+          cursor,
+        });
+
+        safeAck(ack, { ok: true });
+      } catch (error) {
+        console.error("Failed to process cursor update", error);
+        safeAck(ack, {
+          ok: false,
+          error: error.message,
+        });
+      }
+    });
+
+    socket.on("session:leave", (payload, ack) => {
+      try {
+        const { sessionId, userId } = resolveSessionAndUser(socket, payload);
+
+        if (!sessionId || !userId) {
+          safeAck(ack, {
+            ok: false,
+            error: "sessionId and userId are required",
+          });
+          return;
+        }
+
+        store.markParticipantDisconnected(sessionId, userId);
+        socket.leave(sessionId);
+
+        socket.to(sessionId).emit("session:user-left", {
+          sessionId,
+          userId,
+        });
+
+        safeAck(ack, { ok: true });
+      } catch (error) {
+        console.error("Failed to leave session", error);
+        safeAck(ack, {
+          ok: false,
+          error: error.message,
+        });
+      }
+    });
+
+    socket.on("disconnect", () => {
+      const { sessionId, userId } = socket.data;
+
+      if (!sessionId || !userId) {
+        return;
+      }
+
+      const participant = store.markParticipantDisconnected(sessionId, userId);
+
+      socket.to(sessionId).emit("session:user-disconnected", {
+        sessionId,
+        userId,
+        participant,
+      });
+    });
+  });
+};
+
+export default registerCollaborationHandlers;

--- a/backend/services/collaboration_service/src/store/sessionStore.js
+++ b/backend/services/collaboration_service/src/store/sessionStore.js
@@ -1,0 +1,216 @@
+const DEFAULT_CODE = "";
+
+const createSessionRecord = ({
+  sessionId,
+  initialCode = DEFAULT_CODE,
+  question = null,
+}) => {
+  const now = new Date().toISOString();
+
+  return {
+    id: sessionId,
+    code: initialCode,
+    version: 0,
+    question,
+    participants: new Map(),
+    createdAt: now,
+    updatedAt: now,
+    lastChange: null,
+  };
+};
+
+const cloneParticipant = (participant) => ({
+  userId: participant.userId,
+  displayName: participant.displayName,
+  connected: participant.connected,
+  cursor: participant.cursor,
+  joinedAt: participant.joinedAt,
+  lastSeenAt: participant.lastSeenAt,
+});
+
+const snapshotSession = (session) => ({
+  id: session.id,
+  code: session.code,
+  version: session.version,
+  question: session.question,
+  participants: Array.from(session.participants.values()).map((participant) =>
+    cloneParticipant(participant)
+  ),
+  createdAt: session.createdAt,
+  updatedAt: session.updatedAt,
+  lastChange: session.lastChange,
+});
+
+export class SessionStore {
+  constructor() {
+    this.sessions = new Map();
+  }
+
+  ensureSession(sessionId, { initialCode, question } = {}) {
+    if (!sessionId) {
+      throw new Error("A session identifier is required");
+    }
+
+    const existing = this.sessions.get(sessionId);
+
+    if (existing) {
+      return { session: existing, created: false };
+    }
+
+    const session = createSessionRecord({
+      sessionId,
+      initialCode,
+      question: question
+        ? { ...question, updatedAt: new Date().toISOString() }
+        : null,
+    });
+
+    this.sessions.set(sessionId, session);
+
+    return { session, created: true };
+  }
+
+  getSession(sessionId) {
+    return this.sessions.get(sessionId) ?? null;
+  }
+
+  getSessionSnapshot(sessionId) {
+    const session = this.getSession(sessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    return snapshotSession(session);
+  }
+
+  addOrUpdateParticipant(sessionId, { userId, displayName, socketId }) {
+    if (!userId) {
+      throw new Error("A user identifier is required to join a session");
+    }
+
+    const { session } = this.ensureSession(sessionId);
+    const existing = session.participants.get(userId);
+    const now = new Date().toISOString();
+
+    const participantRecord = {
+      userId,
+      displayName: displayName ?? existing?.displayName ?? null,
+      connected: true,
+      cursor: existing?.cursor ?? null,
+      joinedAt: existing?.joinedAt ?? now,
+      lastSeenAt: now,
+      socketId,
+    };
+
+    session.participants.set(userId, participantRecord);
+    session.updatedAt = now;
+
+    return {
+      participant: cloneParticipant(participantRecord),
+      isNewParticipant: !existing,
+      session,
+    };
+  }
+
+  markParticipantDisconnected(sessionId, userId) {
+    const session = this.getSession(sessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    const participant = session.participants.get(userId);
+
+    if (!participant) {
+      return null;
+    }
+
+    participant.connected = false;
+    participant.socketId = null;
+    participant.lastSeenAt = new Date().toISOString();
+    session.updatedAt = participant.lastSeenAt;
+
+    return cloneParticipant(participant);
+  }
+
+  removeParticipant(sessionId, userId) {
+    const session = this.getSession(sessionId);
+
+    if (!session) {
+      return false;
+    }
+
+    const removed = session.participants.delete(userId);
+
+    if (removed) {
+      session.updatedAt = new Date().toISOString();
+    }
+
+    return removed;
+  }
+
+  updateParticipantCursor(sessionId, userId, cursor) {
+    const session = this.getSession(sessionId);
+
+    if (!session) {
+      return null;
+    }
+
+    const participant = session.participants.get(userId);
+
+    if (!participant) {
+      return null;
+    }
+
+    participant.cursor = cursor;
+    participant.lastSeenAt = new Date().toISOString();
+    session.updatedAt = participant.lastSeenAt;
+
+    return cloneParticipant(participant);
+  }
+
+  applyCodeUpdate(sessionId, { userId, fullText, clientVersion, changeId }) {
+    const { session } = this.ensureSession(sessionId);
+    const now = new Date().toISOString();
+    const previousVersion = session.version;
+    const conflict = clientVersion != null && clientVersion !== previousVersion;
+
+    session.code = fullText;
+    session.version = previousVersion + 1;
+    session.updatedAt = now;
+    session.lastChange = {
+      changeId: changeId ?? null,
+      userId: userId ?? null,
+      appliedAt: now,
+      previousVersion,
+      version: session.version,
+      conflict,
+    };
+
+    return {
+      session,
+      conflict,
+      version: session.version,
+      lastChange: session.lastChange,
+    };
+  }
+
+  setQuestion(sessionId, question, { userId } = {}) {
+    const { session } = this.ensureSession(sessionId);
+    const now = new Date().toISOString();
+
+    session.question = {
+      ...question,
+      updatedAt: now,
+      updatedBy: userId ?? null,
+    };
+    session.updatedAt = now;
+
+    return snapshotSession(session);
+  }
+}
+
+export const sessionStore = new SessionStore();
+
+export default sessionStore;


### PR DESCRIPTION
## Summary
- replace the placeholder server with an Express app backed by a shared HTTP/Socket.IO server
- add an in-memory session store with REST endpoints and websocket handlers for joining, editing, cursor updates, and question changes
- document how to run the collaboration service and consume its new APIs

## Testing
- pnpm install *(fails: registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e01791e4108331b1aa6e3e1303e41b