### PR TITLE
feat: implement collaboration service backend

### DIFF
--- a/backend/services/collaboration_service/README.md
+++ b/backend/services/collaboration_service/README.md
@@ -1,0 +1,25 @@
+# Collaboration Service
+
+The collaboration service powers PeerPrep's real-time paired programming experience. It
+provides a REST API and WebSocket gateway for managing collaborative rooms, synchronising
+editor content, coordinating question changes and ensuring that participants can rejoin a
+session within a configurable grace period.
+
+## Getting started
+
+```bash
+pnpm install
+pnpm run dev
+```
+
+The service listens on the port defined by `COLLABORATIONSERVICEPORT` (defaults to `4004`).
+Swagger documentation is automatically hosted at `/docs`.
+
+## Key capabilities
+
+- Create, join and reconnect to collaboration rooms that support up to two participants.
+- Propagate editor operations with optimistic locking and last-write-wins conflict
+  resolution.
+- Coordinate collaborative question changes that require mutual consent.
+- Gracefully handle disconnects with a five-minute reconnection window.
+- Expose WebSocket channels (via Socket.IO) for real-time updates consumed by the web app.

--- a/backend/services/collaboration_service/index.js
+++ b/backend/services/collaboration_service/index.js
@@ -1,13 +1,7 @@
-import express from "express";
+import { config } from "dotenv";
+import { CollaborationApplication } from "./src/CollaborationApplication.js";
 
-const port = process.env.COLLABORATIONSERVICEPORT || 4004;
+config();
 
-const app = express();
-
-app.get("/status", (req, res) => {
-  res.send("Collaboration service is up and running!");
-});
-
-app.listen(port, () => {
-  console.log(`Collaboration service is running on port ${port}`);
-});
+const application = new CollaborationApplication();
+application.start();

--- a/backend/services/collaboration_service/package.json
+++ b/backend/services/collaboration_service/package.json
@@ -15,7 +15,8 @@
     "express": "^5.1.0",
     "express-jsdoc-swagger": "^1.8.0",
     "mongodb": "^6.20.0",
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "socket.io": "^4.7.5"
   },
   "type": "module"
 }

--- a/backend/services/collaboration_service/src/CollaborationApplication.js
+++ b/backend/services/collaboration_service/src/CollaborationApplication.js
@@ -1,0 +1,74 @@
+import http from "http";
+import express from "express";
+import { Server as SocketIOServer } from "socket.io";
+import { MongoClientInstance } from "../../../common_scripts/mongo.js";
+import { startSwaggerDocs } from "../../../common_scripts/swagger_docs.js";
+import { CollaborationSessionRepository } from "./repositories/CollaborationSessionRepository.js";
+import { CollaborationSessionService } from "./services/CollaborationSessionService.js";
+import {
+  CollaborationController,
+  errorMiddleware,
+} from "./controllers/CollaborationController.js";
+import { createCollaborationRouter } from "./routes/collaborationRoutes.js";
+import { CollaborationSocketManager } from "./websocket/CollaborationSocketManager.js";
+
+export class CollaborationApplication {
+  constructor({ port = process.env.COLLABORATIONSERVICEPORT || 4004 } = {}) {
+    this.port = port;
+    this.app = null;
+    this.server = null;
+    this.socketManager = null;
+  }
+
+  async init() {
+    if (this.app) {
+      return this.app;
+    }
+
+    await MongoClientInstance.start();
+    const repository = await CollaborationSessionRepository.initialize(MongoClientInstance.db);
+    const collaborationService = new CollaborationSessionService({ repository });
+    const controller = new CollaborationController(collaborationService);
+    const socketManager = new CollaborationSocketManager({ collaborationService });
+
+    const app = express();
+    app.enable("trust proxy");
+    app.use(express.json());
+
+    startSwaggerDocs(app, "Collaboration Service API", this.port);
+
+    app.get("/status", (_req, res) => {
+      res.json({ status: "Collaboration service is running" });
+    });
+
+    app.use("/api/collaboration", createCollaborationRouter(controller));
+    app.use(errorMiddleware);
+
+    this.app = app;
+    this.socketManager = socketManager;
+    return app;
+  }
+
+  async start() {
+    const app = await this.init();
+
+    const server = http.createServer(app);
+    const io = new SocketIOServer(server, {
+      cors: {
+        origin: process.env.COLLABORATION_SOCKET_CORS_ORIGIN || "*",
+        methods: ["GET", "POST"],
+      },
+    });
+
+    this.socketManager.bind(io);
+
+    return new Promise((resolve) => {
+      server.listen(this.port, () => {
+        console.log(`Collaboration service listening on port ${this.port}`);
+        this.server = server;
+        this.io = io;
+        resolve(server);
+      });
+    });
+  }
+}

--- a/backend/services/collaboration_service/src/controllers/CollaborationController.js
+++ b/backend/services/collaboration_service/src/controllers/CollaborationController.js
@@ -1,0 +1,167 @@
+import { ApiError } from "../errors/ApiError.js";
+
+export class CollaborationController {
+  constructor(collaborationService) {
+    this.collaborationService = collaborationService;
+  }
+
+  createSession = async (req, res, next) => {
+    try {
+      const session = await this.collaborationService.createSession(req.body ?? {});
+      res.status(201).json({
+        message: "Collaboration session created successfully.",
+        session,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getSession = async (req, res, next) => {
+    try {
+      const session = await this.collaborationService.getSession(req.params.sessionId);
+      res.json({ session });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getSessionByRoomId = async (req, res, next) => {
+    try {
+      const session = await this.collaborationService.getSessionByRoomId(req.params.roomId);
+      res.json({ session });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  joinSession = async (req, res, next) => {
+    try {
+      const session = await this.collaborationService.joinSession(req.params.sessionId, req.body ?? {});
+      res.json({
+        message: "Joined collaboration session successfully.",
+        session,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  submitOperation = async (req, res, next) => {
+    try {
+      const result = await this.collaborationService.recordOperation(req.params.sessionId, {
+        ...req.body,
+        userId: req.body?.userId,
+      });
+      res.json({
+        message: result.conflict
+          ? "Operation applied with conflict resolution."
+          : "Operation applied successfully.",
+        ...result,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  leaveSession = async (req, res, next) => {
+    try {
+      const session = await this.collaborationService.leaveSession(req.params.sessionId, req.body ?? {});
+      res.json({
+        message: "Leave request processed successfully.",
+        session,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  reconnectParticipant = async (req, res, next) => {
+    try {
+      const session = await this.collaborationService.reconnectParticipant(
+        req.params.sessionId,
+        req.body?.userId,
+      );
+      res.json({
+        message: "Reconnected to collaboration session successfully.",
+        session,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  proposeQuestionChange = async (req, res, next) => {
+    try {
+      const session = await this.collaborationService.proposeQuestionChange(
+        req.params.sessionId,
+        req.body ?? {},
+      );
+      res.json({
+        message: "Question change proposed successfully.",
+        session,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  respondToQuestionChange = async (req, res, next) => {
+    try {
+      const session = await this.collaborationService.respondToQuestionChange(
+        req.params.sessionId,
+        req.body ?? {},
+      );
+      res.json({
+        message: "Question change response recorded successfully.",
+        session,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  requestSessionEnd = async (req, res, next) => {
+    try {
+      const session = await this.collaborationService.requestSessionEnd(
+        req.params.sessionId,
+        req.body ?? {},
+      );
+      res.json({
+        message: "Session end preference updated successfully.",
+        session,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  terminateSession = async (req, res, next) => {
+    try {
+      if (!req.body?.reason || req.body.reason !== "admin") {
+        throw new ApiError(403, "Unauthorized to terminate session.");
+      }
+      const session = await this.collaborationService.terminateSession(req.params.sessionId);
+      res.json({
+        message: "Session terminated successfully.",
+        session,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+export const errorMiddleware = (err, req, res, _next) => {
+  if (err instanceof ApiError) {
+    const payload = { message: err.message };
+    if (Array.isArray(err.details)) {
+      payload.errors = err.details;
+    }
+    res.status(err.status).json(payload);
+    return;
+  }
+
+  console.error(err);
+  res.status(500).json({ message: "An unexpected error occurred." });
+};

--- a/backend/services/collaboration_service/src/errors/ApiError.js
+++ b/backend/services/collaboration_service/src/errors/ApiError.js
@@ -1,0 +1,10 @@
+export class ApiError extends Error {
+  constructor(status, message, details = null) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    if (details !== null) {
+      this.details = details;
+    }
+  }
+}

--- a/backend/services/collaboration_service/src/repositories/CollaborationSessionRepository.js
+++ b/backend/services/collaboration_service/src/repositories/CollaborationSessionRepository.js
@@ -1,0 +1,105 @@
+import { ObjectId } from "mongodb";
+
+export class CollaborationSessionRepository {
+  constructor(db) {
+    this.collection = db.collection("collaboration_sessions");
+  }
+
+  static async initialize(db) {
+    const repository = new CollaborationSessionRepository(db);
+    await repository.ensureIndexes();
+    return repository;
+  }
+
+  async ensureIndexes() {
+    await Promise.all([
+      this.collection.createIndex({ roomId: 1 }, { unique: true, name: "uniq_room" }),
+      this.collection.createIndex({ "participants.userId": 1 }, { name: "participants_user" }),
+      this.collection.createIndex({ status: 1, updatedAt: 1 }, { name: "status_updated" }),
+    ]);
+  }
+
+  buildUpdate({ set = {}, unset = {}, inc = {}, push = {}, pull = {} } = {}) {
+    const update = {};
+    const now = new Date();
+    update.$set = { updatedAt: now, ...set };
+
+    if (Object.keys(unset).length > 0) {
+      update.$unset = unset;
+    }
+
+    if (Object.keys(inc).length > 0) {
+      update.$inc = inc;
+    }
+
+    if (Object.keys(push).length > 0) {
+      update.$push = push;
+    }
+
+    if (Object.keys(pull).length > 0) {
+      update.$pull = pull;
+    }
+
+    return update;
+  }
+
+  async create(payload) {
+    const now = new Date();
+    const doc = {
+      ...payload,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const result = await this.collection.insertOne(doc);
+    return { ...doc, _id: result.insertedId };
+  }
+
+  async findById(id) {
+    if (!ObjectId.isValid(id)) {
+      return null;
+    }
+    return this.collection.findOne({ _id: new ObjectId(id) });
+  }
+
+  async findByRoomId(roomId) {
+    return this.collection.findOne({ roomId });
+  }
+
+  async updateById(id, operations, options = {}) {
+    if (!ObjectId.isValid(id)) {
+      return null;
+    }
+    const update = this.buildUpdate(operations);
+    const result = await this.collection.findOneAndUpdate(
+      { _id: new ObjectId(id) },
+      update,
+      { returnDocument: "after", ...options },
+    );
+    return result.value;
+  }
+
+  async updateOne(filter, operations, options = {}) {
+    const update = this.buildUpdate(operations);
+    const result = await this.collection.findOneAndUpdate(filter, update, {
+      returnDocument: "after",
+      ...options,
+    });
+    return result.value;
+  }
+
+  async deleteById(id) {
+    if (!ObjectId.isValid(id)) {
+      return false;
+    }
+    const result = await this.collection.deleteOne({ _id: new ObjectId(id) });
+    return result.deletedCount === 1;
+  }
+
+  async removeExpiredSessions(expiryDate) {
+    const result = await this.collection.deleteMany({
+      status: { $in: ["expired", "ended"] },
+      updatedAt: { $lt: expiryDate },
+    });
+    return result.deletedCount;
+  }
+}

--- a/backend/services/collaboration_service/src/routes/collaborationRoutes.js
+++ b/backend/services/collaboration_service/src/routes/collaborationRoutes.js
@@ -1,0 +1,73 @@
+import { Router } from "express";
+
+export const createCollaborationRouter = (controller) => {
+  const router = Router();
+
+  /**
+   * POST /sessions
+   * @summary Create a new collaboration session
+   */
+  router.post("/sessions", controller.createSession);
+
+  /**
+   * GET /sessions/:sessionId
+   * @summary Fetch a collaboration session by its identifier
+   */
+  router.get("/sessions/:sessionId", controller.getSession);
+
+  /**
+   * GET /rooms/:roomId
+   * @summary Fetch an active collaboration session using the public room id
+   */
+  router.get("/rooms/:roomId", controller.getSessionByRoomId);
+
+  /**
+   * POST /sessions/:sessionId/join
+   * @summary Join an existing collaboration session
+   */
+  router.post("/sessions/:sessionId/join", controller.joinSession);
+
+  /**
+   * POST /sessions/:sessionId/operations
+   * @summary Submit an editor operation for the collaboration session
+   */
+  router.post("/sessions/:sessionId/operations", controller.submitOperation);
+
+  /**
+   * POST /sessions/:sessionId/leave
+   * @summary Leave the collaboration session or request termination
+   */
+  router.post("/sessions/:sessionId/leave", controller.leaveSession);
+
+  /**
+   * POST /sessions/:sessionId/reconnect
+   * @summary Reconnect a participant that temporarily disconnected
+   */
+  router.post("/sessions/:sessionId/reconnect", controller.reconnectParticipant);
+
+  /**
+   * POST /sessions/:sessionId/question/propose
+   * @summary Propose a new question for the collaboration session
+   */
+  router.post("/sessions/:sessionId/question/propose", controller.proposeQuestionChange);
+
+  /**
+   * POST /sessions/:sessionId/question/respond
+   * @summary Respond to a pending question change proposal
+   */
+  router.post("/sessions/:sessionId/question/respond", controller.respondToQuestionChange);
+
+  /**
+   * POST /sessions/:sessionId/end
+   * @summary Request to end the collaboration session (requires both participants)
+   */
+  router.post("/sessions/:sessionId/end", controller.requestSessionEnd);
+
+  /**
+   * POST /sessions/:sessionId/terminate
+   * @summary Administrative termination of a collaboration session
+   */
+  router.post("/sessions/:sessionId/terminate", controller.terminateSession);
+
+  return router;
+};

--- a/backend/services/collaboration_service/src/services/CollaborationSessionService.js
+++ b/backend/services/collaboration_service/src/services/CollaborationSessionService.js
@@ -1,0 +1,647 @@
+import crypto from "crypto";
+import { ApiError } from "../errors/ApiError.js";
+import {
+  CollaborationSessionValidator,
+} from "../validators/CollaborationSessionValidator.js";
+
+const MAX_PARTICIPANTS = 2;
+const DEFAULT_LANGUAGE = "javascript";
+const RECONNECT_WINDOW_MS = 5 * 60 * 1000;
+const LOCK_DURATION_MS = 1_500;
+
+export class CollaborationSessionService {
+  constructor({ repository, timeProvider = () => new Date() } = {}) {
+    this.repository = repository;
+    this.timeProvider = timeProvider;
+    this.lockDurationMs = LOCK_DURATION_MS;
+    this.reconnectWindowMs = RECONNECT_WINDOW_MS;
+    this.locks = new Map();
+  }
+
+  now() {
+    const value = this.timeProvider();
+    return value instanceof Date ? value : new Date(value);
+  }
+
+  sanitizeSession(session) {
+    if (!session) return null;
+    const sanitizedParticipants = (session.participants ?? []).map((participant) => ({
+      ...participant,
+      userId: participant.userId,
+      joinedAt: participant.joinedAt?.toISOString?.() ?? participant.joinedAt,
+      lastSeenAt: participant.lastSeenAt?.toISOString?.() ?? participant.lastSeenAt,
+      disconnectedAt:
+        participant.disconnectedAt?.toISOString?.() ?? participant.disconnectedAt ?? null,
+      reconnectBy:
+        participant.reconnectBy?.toISOString?.() ?? participant.reconnectBy ?? null,
+    }));
+
+    return {
+      id: session._id?.toString?.() ?? session._id,
+      roomId: session.roomId,
+      title: session.title ?? null,
+      questionId: session.questionId ?? null,
+      language: session.language ?? DEFAULT_LANGUAGE,
+      codeSnapshot: session.codeSnapshot ?? "",
+      version: session.version ?? 0,
+      status: session.status ?? "active",
+      pendingQuestionChange: session.pendingQuestionChange ?? null,
+      participants: sanitizedParticipants,
+      cursorPositions: session.cursorPositions ?? {},
+      lastOperation: session.lastOperation ?? null,
+      endRequests: session.endRequests ?? [],
+      createdAt: session.createdAt?.toISOString?.() ?? session.createdAt,
+      updatedAt: session.updatedAt?.toISOString?.() ?? session.updatedAt,
+    };
+  }
+
+  async generateRoomId() {
+    return crypto.randomBytes(3).toString("hex");
+  }
+
+  async generateUniqueRoomId() {
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      const candidate = await this.generateRoomId();
+      const existing = await this.repository.findByRoomId(candidate);
+      if (!existing) {
+        return candidate;
+      }
+    }
+    throw new ApiError(500, "Failed to generate a unique room id. Please try again.");
+  }
+
+  buildParticipant({ userId, displayName }) {
+    const now = this.now();
+    return {
+      userId,
+      displayName: displayName ?? null,
+      connected: true,
+      joinedAt: now,
+      lastSeenAt: now,
+      disconnectedAt: null,
+      reconnectBy: null,
+      endConfirmed: false,
+    };
+  }
+
+  ensureActive(session) {
+    if (!session) {
+      throw new ApiError(404, "Collaboration session not found.");
+    }
+    if (session.status === "ended") {
+      throw new ApiError(410, "This collaboration session has already ended.");
+    }
+  }
+
+  async checkExpiredSession(session) {
+    if (!session || session.status === "ended") {
+      return session;
+    }
+
+    const now = this.now();
+    const participants = session.participants ?? [];
+    const expired = participants.filter(
+      (participant) =>
+        !participant.connected && participant.reconnectBy && participant.reconnectBy < now,
+    );
+
+    if (expired.length === 0) {
+      return session;
+    }
+
+    const expiredIds = new Set(expired.map((item) => item.userId));
+    const updatedParticipants = participants.map((participant) =>
+      expiredIds.has(participant.userId)
+        ? {
+            ...participant,
+            reconnectBy: null,
+            disconnectedAt: participant.disconnectedAt ?? now,
+          }
+        : {
+            ...participant,
+            connected: false,
+            lastSeenAt: now,
+            disconnectedAt: now,
+            reconnectBy: null,
+          },
+    );
+
+    const updated = await this.repository.updateById(session._id, {
+      set: {
+        participants: updatedParticipants,
+        status: "ended",
+      },
+    });
+
+    return updated ?? session;
+  }
+
+  getParticipant(session, userId) {
+    return (session.participants ?? []).find((participant) => participant.userId === userId) ?? null;
+  }
+
+  async createSession(payload) {
+    const { errors, normalized } = CollaborationSessionValidator.validateCreateSession(payload);
+    if (errors.length > 0) {
+      throw new ApiError(400, "Validation failed.", errors);
+    }
+
+    const roomId = normalized.roomId
+      ? await this.ensureRoomIdAvailability(normalized.roomId)
+      : await this.generateUniqueRoomId();
+
+    const now = this.now();
+    const session = await this.repository.create({
+      roomId,
+      title: normalized.title ?? null,
+      language: normalized.language ?? DEFAULT_LANGUAGE,
+      questionId: normalized.questionId ?? null,
+      codeSnapshot: normalized.initialCode ?? "",
+      version: 0,
+      status: "active",
+      participants: [this.buildParticipant({ userId: normalized.hostUserId })],
+      pendingQuestionChange: null,
+      endRequests: [],
+      cursorPositions: {},
+      lastOperation: null,
+      lastConflictAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return this.sanitizeSession(session);
+  }
+
+  async ensureRoomIdAvailability(roomId) {
+    const existing = await this.repository.findByRoomId(roomId);
+    if (existing) {
+      throw new ApiError(409, "Room id is already in use. Please choose another id.");
+    }
+    return roomId;
+  }
+
+  async getSessionByRoomId(roomId) {
+    let session = await this.repository.findByRoomId(roomId);
+    session = await this.checkExpiredSession(session);
+    this.ensureActive(session);
+    return this.sanitizeSession(session);
+  }
+
+  async getSession(sessionId) {
+    let session = await this.repository.findById(sessionId);
+    session = await this.checkExpiredSession(session);
+    this.ensureActive(session);
+    return this.sanitizeSession(session);
+  }
+
+  async joinSession(sessionId, payload) {
+    const { errors, normalized } = CollaborationSessionValidator.validateJoinSession(payload);
+    if (errors.length > 0) {
+      throw new ApiError(400, "Validation failed.", errors);
+    }
+
+    let session = await this.repository.findById(sessionId);
+    session = await this.checkExpiredSession(session);
+    this.ensureActive(session);
+
+    const now = this.now();
+    const participants = session.participants ?? [];
+    const participant = this.getParticipant(session, normalized.userId);
+
+    if (!participant && participants.length >= MAX_PARTICIPANTS) {
+      throw new ApiError(409, "The collaboration room is full.");
+    }
+
+    let updatedParticipants;
+    if (participant) {
+      updatedParticipants = participants.map((item) =>
+        item.userId === normalized.userId
+          ? {
+              ...item,
+              connected: true,
+              lastSeenAt: now,
+              disconnectedAt: null,
+              reconnectBy: null,
+              displayName: normalized.displayName ?? item.displayName ?? null,
+            }
+          : item,
+      );
+    } else {
+      updatedParticipants = [
+        ...participants,
+        this.buildParticipant({
+          userId: normalized.userId,
+          displayName: normalized.displayName,
+        }),
+      ];
+    }
+
+    const updatedSession = await this.repository.updateById(sessionId, {
+      set: {
+        participants: updatedParticipants,
+        status: "active",
+      },
+    });
+
+    return this.sanitizeSession(updatedSession);
+  }
+
+  async recordOperation(sessionId, payload) {
+    const { errors, normalized } = CollaborationSessionValidator.validateOperation(payload);
+    if (errors.length > 0) {
+      throw new ApiError(400, "Validation failed.", errors);
+    }
+
+    let session = await this.repository.findById(sessionId);
+    session = await this.checkExpiredSession(session);
+    this.ensureActive(session);
+
+    const participant = this.getParticipant(session, normalized.userId);
+    if (!participant) {
+      throw new ApiError(403, "You are not part of this collaboration session.");
+    }
+
+    const now = this.now();
+    const lockResult = this.acquireLock(sessionId, normalized.userId, normalized.range, now);
+    if (!lockResult.granted) {
+      return {
+        session: this.sanitizeSession(session),
+        conflict: true,
+        reason: "lock_conflict",
+        lockedBy: lockResult.lockedBy,
+      };
+    }
+
+    const conflict = normalized.version !== (session.version ?? 0);
+    const newVersion = (session.version ?? 0) + 1;
+
+    const updatedParticipants = (session.participants ?? []).map((item) =>
+      item.userId === normalized.userId
+        ? { ...item, lastSeenAt: now, connected: true, disconnectedAt: null, reconnectBy: null }
+        : item,
+    );
+
+    const cursorPositions = {
+      ...(session.cursorPositions ?? {}),
+    };
+    if (normalized.cursor) {
+      cursorPositions[normalized.userId] = {
+        ...normalized.cursor,
+        updatedAt: now,
+      };
+    }
+
+    const updatedSession = await this.repository.updateById(sessionId, {
+      set: {
+        codeSnapshot:
+          normalized.type === "cursor" || normalized.type === "selection"
+            ? session.codeSnapshot
+            : normalized.content ?? session.codeSnapshot,
+        version: newVersion,
+        participants: updatedParticipants,
+        cursorPositions,
+        lastOperation: {
+          userId: normalized.userId,
+          type: normalized.type,
+          version: newVersion,
+          timestamp: now,
+          conflict,
+        },
+        lastConflictAt: conflict ? now : session.lastConflictAt ?? null,
+      },
+    });
+
+    this.releaseLock(sessionId, normalized.userId, normalized.range);
+
+    return {
+      session: this.sanitizeSession(updatedSession),
+      conflict,
+    };
+  }
+
+  acquireLock(sessionId, userId, range, now = this.now()) {
+    if (!range) {
+      return { granted: true };
+    }
+
+    const locks = this.locks.get(sessionId) ?? [];
+    const validLocks = locks.filter((lock) => lock.expiresAt > now);
+
+    const conflicting = validLocks.find(
+      (lock) => lock.userId !== userId && this.rangesOverlap(lock.range, range),
+    );
+    if (conflicting) {
+      this.locks.set(sessionId, validLocks);
+      return { granted: false, lockedBy: conflicting.userId };
+    }
+
+    const expiresAt = new Date(now.getTime() + this.lockDurationMs);
+    const updatedLocks = validLocks.filter((lock) =>
+      !(lock.userId === userId && this.rangesOverlap(lock.range, range)),
+    );
+    updatedLocks.push({ userId, range, expiresAt });
+    this.locks.set(sessionId, updatedLocks);
+
+    return { granted: true };
+  }
+
+  releaseLock(sessionId, userId, range) {
+    if (!range) {
+      return;
+    }
+    const locks = this.locks.get(sessionId);
+    if (!locks) return;
+
+    const remaining = locks.filter(
+      (lock) => !(lock.userId === userId && this.rangesOverlap(lock.range, range)),
+    );
+    if (remaining.length === 0) {
+      this.locks.delete(sessionId);
+    } else {
+      this.locks.set(sessionId, remaining);
+    }
+  }
+
+  rangesOverlap(a, b) {
+    if (!a || !b) return false;
+    return a.start <= b.end && b.start <= a.end;
+  }
+
+  async leaveSession(sessionId, payload) {
+    const { errors, normalized } = CollaborationSessionValidator.validateLeaveSession(payload);
+    if (errors.length > 0) {
+      throw new ApiError(400, "Validation failed.", errors);
+    }
+
+    let session = await this.repository.findById(sessionId);
+    session = await this.checkExpiredSession(session);
+    this.ensureActive(session);
+
+    const participant = this.getParticipant(session, normalized.userId);
+    if (!participant) {
+      throw new ApiError(403, "You are not part of this collaboration session.");
+    }
+
+    const now = this.now();
+    let updatedStatus = session.status;
+    let updatedParticipants = session.participants ?? [];
+
+    if (normalized.terminateForAll) {
+      updatedStatus = "ended";
+      updatedParticipants = updatedParticipants.map((item) =>
+        item.userId === normalized.userId
+          ? { ...item, connected: false, lastSeenAt: now, disconnectedAt: now }
+          : item,
+      );
+    } else {
+      updatedParticipants = updatedParticipants.map((item) =>
+        item.userId === normalized.userId
+          ? {
+              ...item,
+              connected: false,
+              disconnectedAt: now,
+              reconnectBy: new Date(now.getTime() + this.reconnectWindowMs),
+              lastSeenAt: now,
+            }
+          : item,
+      );
+    }
+
+    const activeParticipants = updatedParticipants.filter((item) => item.connected);
+    if (activeParticipants.length === 0) {
+      updatedStatus = "ended";
+    }
+
+    const updatedSession = await this.repository.updateById(sessionId, {
+      set: {
+        participants: updatedParticipants,
+        status: updatedStatus,
+      },
+    });
+
+    this.releaseAllLocksForUser(sessionId, normalized.userId);
+
+    return this.sanitizeSession(updatedSession);
+  }
+
+  async reconnectParticipant(sessionId, userId) {
+    let session = await this.repository.findById(sessionId);
+    session = await this.checkExpiredSession(session);
+    this.ensureActive(session);
+
+    const participant = this.getParticipant(session, userId);
+    if (!participant) {
+      throw new ApiError(403, "You are not part of this collaboration session.");
+    }
+
+    const now = this.now();
+    if (participant.reconnectBy && participant.reconnectBy < now) {
+      throw new ApiError(410, "Reconnection window has expired.");
+    }
+
+    const updatedParticipants = (session.participants ?? []).map((item) =>
+      item.userId === userId
+        ? {
+            ...item,
+            connected: true,
+            disconnectedAt: null,
+            reconnectBy: null,
+            lastSeenAt: now,
+          }
+        : item,
+    );
+
+    const updatedSession = await this.repository.updateById(sessionId, {
+      set: {
+        participants: updatedParticipants,
+        status: "active",
+      },
+    });
+
+    return this.sanitizeSession(updatedSession);
+  }
+
+  releaseAllLocksForUser(sessionId, userId) {
+    const locks = this.locks.get(sessionId);
+    if (!locks) return;
+    const remaining = locks.filter((lock) => lock.userId !== userId);
+    if (remaining.length === 0) {
+      this.locks.delete(sessionId);
+    } else {
+      this.locks.set(sessionId, remaining);
+    }
+  }
+
+  async expireSessionIfNeeded(session) {
+    if (!session) return null;
+    const participants = session.participants ?? [];
+    const now = this.now();
+    const someoneCanReconnect = participants.some(
+      (participant) =>
+        !participant.connected && participant.reconnectBy && participant.reconnectBy > now,
+    );
+    if (someoneCanReconnect) {
+      return null;
+    }
+
+    if (participants.every((participant) => !participant.connected)) {
+      const updated = await this.repository.updateById(session._id, {
+        set: { status: "ended" },
+      });
+      return this.sanitizeSession(updated);
+    }
+
+    return null;
+  }
+
+  async proposeQuestionChange(sessionId, payload) {
+    const { errors, normalized } = CollaborationSessionValidator.validateQuestionProposal(payload);
+    if (errors.length > 0) {
+      throw new ApiError(400, "Validation failed.", errors);
+    }
+
+    let session = await this.repository.findById(sessionId);
+    session = await this.checkExpiredSession(session);
+    this.ensureActive(session);
+
+    const participant = this.getParticipant(session, normalized.userId);
+    if (!participant) {
+      throw new ApiError(403, "You are not part of this collaboration session.");
+    }
+
+    if (session.pendingQuestionChange) {
+      throw new ApiError(409, "There is already a pending question change request.");
+    }
+
+    const now = this.now();
+    const pendingQuestionChange = {
+      questionId: normalized.questionId,
+      proposedBy: normalized.userId,
+      rationale: normalized.rationale ?? null,
+      approvals: [normalized.userId],
+      createdAt: now,
+    };
+
+    const updatedSession = await this.repository.updateById(sessionId, {
+      set: {
+        pendingQuestionChange,
+      },
+    });
+
+    return this.sanitizeSession(updatedSession);
+  }
+
+  async respondToQuestionChange(sessionId, payload) {
+    const { errors, normalized } = CollaborationSessionValidator.validateQuestionResponse(payload);
+    if (errors.length > 0) {
+      throw new ApiError(400, "Validation failed.", errors);
+    }
+
+    let session = await this.repository.findById(sessionId);
+    session = await this.checkExpiredSession(session);
+    this.ensureActive(session);
+
+    if (!session.pendingQuestionChange) {
+      throw new ApiError(404, "There is no pending question change request.");
+    }
+
+    const participant = this.getParticipant(session, normalized.userId);
+    if (!participant) {
+      throw new ApiError(403, "You are not part of this collaboration session.");
+    }
+
+    const pending = session.pendingQuestionChange;
+
+    if (!normalized.accept) {
+      const updatedSession = await this.repository.updateById(sessionId, {
+        set: { pendingQuestionChange: null },
+      });
+      return this.sanitizeSession(updatedSession);
+    }
+
+    const approvals = new Set(pending.approvals ?? []);
+    approvals.add(normalized.userId);
+
+    const participants = session.participants ?? [];
+    const everyoneApproved = participants
+      .filter((p) => !!p)
+      .every((p) => approvals.has(p.userId));
+
+    if (everyoneApproved) {
+      const updatedSession = await this.repository.updateById(sessionId, {
+        set: {
+          pendingQuestionChange: null,
+          questionId: pending.questionId,
+          codeSnapshot: "",
+          version: 0,
+        },
+      });
+      return this.sanitizeSession(updatedSession);
+    }
+
+    const updatedSession = await this.repository.updateById(sessionId, {
+      set: {
+        pendingQuestionChange: {
+          ...pending,
+          approvals: Array.from(approvals),
+        },
+      },
+    });
+
+    return this.sanitizeSession(updatedSession);
+  }
+
+  async requestSessionEnd(sessionId, payload) {
+    const { errors, normalized } = CollaborationSessionValidator.validateEndSessionRequest(payload);
+    if (errors.length > 0) {
+      throw new ApiError(400, "Validation failed.", errors);
+    }
+
+    const session = await this.repository.findById(sessionId);
+    this.ensureActive(session);
+
+    const participant = this.getParticipant(session, normalized.userId);
+    if (!participant) {
+      throw new ApiError(403, "You are not part of this collaboration session.");
+    }
+
+    const approvals = new Set(session.endRequests ?? []);
+    if (normalized.confirm) {
+      approvals.add(normalized.userId);
+    } else {
+      approvals.delete(normalized.userId);
+    }
+
+    const participants = session.participants ?? [];
+    const everyoneApproved =
+      approvals.size > 0 && participants.every((p) => approvals.has(p.userId));
+
+    if (everyoneApproved) {
+      const updatedSession = await this.repository.updateById(sessionId, {
+        set: {
+          status: "ended",
+          endRequests: Array.from(approvals),
+        },
+      });
+      return this.sanitizeSession(updatedSession);
+    }
+
+    const updatedSession = await this.repository.updateById(sessionId, {
+      set: {
+        endRequests: Array.from(approvals),
+      },
+    });
+
+    return this.sanitizeSession(updatedSession);
+  }
+
+  async terminateSession(sessionId) {
+    const session = await this.repository.updateById(sessionId, {
+      set: { status: "ended" },
+    });
+    if (!session) {
+      throw new ApiError(404, "Collaboration session not found.");
+    }
+    return this.sanitizeSession(session);
+  }
+}

--- a/backend/services/collaboration_service/src/validators/CollaborationSessionValidator.js
+++ b/backend/services/collaboration_service/src/validators/CollaborationSessionValidator.js
@@ -1,0 +1,239 @@
+const LOCK_TYPES = ["insert", "delete", "replace", "cursor", "selection"];
+
+export class CollaborationSessionValidator {
+  static normalizeString(value) {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  static validateCreateSession(payload = {}) {
+    const errors = [];
+    const normalized = {};
+
+    const hostUserId = this.normalizeString(payload.hostUserId);
+    if (!hostUserId) {
+      errors.push({ field: "hostUserId", message: "hostUserId is required." });
+    } else {
+      normalized.hostUserId = hostUserId;
+    }
+
+    const roomId = this.normalizeString(payload.roomId);
+    if (roomId) {
+      normalized.roomId = roomId;
+    }
+
+    const questionId = this.normalizeString(payload.questionId);
+    if (questionId) {
+      normalized.questionId = questionId;
+    }
+
+    const language = this.normalizeString(payload.language) ?? "javascript";
+    normalized.language = language;
+
+    const initialCode = typeof payload.initialCode === "string" ? payload.initialCode : "";
+    normalized.initialCode = initialCode;
+
+    const title = this.normalizeString(payload.title);
+    if (title) {
+      normalized.title = title;
+    }
+
+    return { errors, normalized };
+  }
+
+  static validateJoinSession(payload = {}) {
+    const errors = [];
+    const normalized = {};
+
+    const userId = this.normalizeString(payload.userId);
+    if (!userId) {
+      errors.push({ field: "userId", message: "userId is required." });
+    } else {
+      normalized.userId = userId;
+    }
+
+    const roomId = this.normalizeString(payload.roomId);
+    if (roomId) {
+      normalized.roomId = roomId;
+    }
+
+    const displayName = this.normalizeString(payload.displayName);
+    if (displayName) {
+      normalized.displayName = displayName;
+    }
+
+    return { errors, normalized };
+  }
+
+  static validateOperation(payload = {}) {
+    const errors = [];
+    const normalized = {};
+
+    const userId = this.normalizeString(payload.userId);
+    if (!userId) {
+      errors.push({ field: "userId", message: "userId is required." });
+    } else {
+      normalized.userId = userId;
+    }
+
+    const version = Number(payload.version);
+    if (!Number.isInteger(version) || version < 0) {
+      errors.push({ field: "version", message: "version must be a non-negative integer." });
+    } else {
+      normalized.version = version;
+    }
+
+    const type = this.normalizeString(payload.type);
+    if (!type || !LOCK_TYPES.includes(type)) {
+      errors.push({ field: "type", message: "type must be one of insert, delete, replace, cursor, selection." });
+    } else {
+      normalized.type = type;
+    }
+
+    if (payload.range != null) {
+      const range = this.validateRange(payload.range, errors);
+      if (range) {
+        normalized.range = range;
+      }
+    }
+
+    if (payload.cursor != null) {
+      const cursor = this.validateCursor(payload.cursor, errors);
+      if (cursor) {
+        normalized.cursor = cursor;
+      }
+    }
+
+    const content = typeof payload.content === "string" ? payload.content : null;
+    if (content == null && ["insert", "delete", "replace"].includes(normalized.type)) {
+      errors.push({ field: "content", message: "content must be provided for text-changing operations." });
+    } else if (content != null) {
+      normalized.content = content;
+    }
+
+    return { errors, normalized };
+  }
+
+  static validateRange(range, errors) {
+    const start = Number(range?.start);
+    const end = Number(range?.end);
+
+    if (!Number.isInteger(start) || start < 0) {
+      errors.push({ field: "range.start", message: "range.start must be a non-negative integer." });
+      return null;
+    }
+    if (!Number.isInteger(end) || end < start) {
+      errors.push({ field: "range.end", message: "range.end must be an integer greater than or equal to start." });
+      return null;
+    }
+
+    return { start, end };
+  }
+
+  static validateCursor(cursor, errors) {
+    const line = Number(cursor?.line);
+    const column = Number(cursor?.column);
+    if (!Number.isInteger(line) || line < 0) {
+      errors.push({ field: "cursor.line", message: "cursor.line must be a non-negative integer." });
+      return null;
+    }
+    if (!Number.isInteger(column) || column < 0) {
+      errors.push({ field: "cursor.column", message: "cursor.column must be a non-negative integer." });
+      return null;
+    }
+    return { line, column };
+  }
+
+  static validateLeaveSession(payload = {}) {
+    const errors = [];
+    const normalized = {};
+
+    const userId = this.normalizeString(payload.userId);
+    if (!userId) {
+      errors.push({ field: "userId", message: "userId is required." });
+    } else {
+      normalized.userId = userId;
+    }
+
+    const reason = this.normalizeString(payload.reason);
+    if (reason) {
+      normalized.reason = reason;
+    }
+
+    const terminateForAll = Boolean(payload.terminateForAll);
+    if (payload.terminateForAll != null) {
+      normalized.terminateForAll = terminateForAll;
+    }
+
+    return { errors, normalized };
+  }
+
+  static validateQuestionProposal(payload = {}) {
+    const errors = [];
+    const normalized = {};
+
+    const userId = this.normalizeString(payload.userId);
+    if (!userId) {
+      errors.push({ field: "userId", message: "userId is required." });
+    } else {
+      normalized.userId = userId;
+    }
+
+    const questionId = this.normalizeString(payload.questionId);
+    if (!questionId) {
+      errors.push({ field: "questionId", message: "questionId is required." });
+    } else {
+      normalized.questionId = questionId;
+    }
+
+    const rationale = this.normalizeString(payload.rationale);
+    if (rationale) {
+      normalized.rationale = rationale;
+    }
+
+    return { errors, normalized };
+  }
+
+  static validateQuestionResponse(payload = {}) {
+    const errors = [];
+    const normalized = {};
+
+    const userId = this.normalizeString(payload.userId);
+    if (!userId) {
+      errors.push({ field: "userId", message: "userId is required." });
+    } else {
+      normalized.userId = userId;
+    }
+
+    if (typeof payload.accept !== "boolean") {
+      errors.push({ field: "accept", message: "accept must be a boolean." });
+    } else {
+      normalized.accept = payload.accept;
+    }
+
+    return { errors, normalized };
+  }
+
+  static validateEndSessionRequest(payload = {}) {
+    const errors = [];
+    const normalized = {};
+
+    const userId = this.normalizeString(payload.userId);
+    if (!userId) {
+      errors.push({ field: "userId", message: "userId is required." });
+    } else {
+      normalized.userId = userId;
+    }
+
+    if (typeof payload.confirm !== "boolean") {
+      errors.push({ field: "confirm", message: "confirm must be a boolean." });
+    } else {
+      normalized.confirm = payload.confirm;
+    }
+
+    return { errors, normalized };
+  }
+}
+
+export { LOCK_TYPES };

--- a/backend/services/collaboration_service/src/websocket/CollaborationSocketManager.js
+++ b/backend/services/collaboration_service/src/websocket/CollaborationSocketManager.js
@@ -1,0 +1,182 @@
+import { ApiError } from "../errors/ApiError.js";
+
+export class CollaborationSocketManager {
+  constructor({ collaborationService, logger = console } = {}) {
+    this.collaborationService = collaborationService;
+    this.logger = logger;
+    this.io = null;
+  }
+
+  bind(io) {
+    this.io = io;
+    io.on("connection", (socket) => {
+      this.logger.info?.("Collaboration socket connected", { socketId: socket.id });
+      this.configureSocket(socket);
+    });
+  }
+
+  configureSocket(socket) {
+    socket.on("session:join", async (payload = {}, callback) => {
+      await this.handleAction(socket, payload, callback, async () => {
+        const { sessionId, userId, displayName } = payload;
+        const session = await this.collaborationService.joinSession(sessionId, {
+          userId,
+          displayName,
+        });
+
+        socket.data.sessionId = session.id;
+        socket.data.userId = userId;
+        socket.data.displayName = displayName ?? null;
+        socket.data.hasLeft = false;
+        socket.join(this.roomName(session.id));
+        this.emitSessionState(session);
+        return { session };
+      });
+    });
+
+    socket.on("session:operation", async (payload = {}, callback) => {
+      await this.handleAction(socket, payload, callback, async () => {
+        const sessionId = payload.sessionId ?? socket.data.sessionId;
+        const userId = payload.userId ?? socket.data.userId;
+        const result = await this.collaborationService.recordOperation(sessionId, {
+          ...payload,
+          userId,
+        });
+        this.io
+          ?.to(this.roomName(result.session.id))
+          .emit("session:operation", { session: result.session, conflict: result.conflict });
+        return result;
+      });
+    });
+
+    socket.on("session:leave", async (payload = {}, callback) => {
+      await this.handleAction(socket, payload, callback, async () => {
+        const sessionId = payload.sessionId ?? socket.data.sessionId;
+        const userId = payload.userId ?? socket.data.userId;
+        const session = await this.collaborationService.leaveSession(sessionId, {
+          ...payload,
+          userId,
+        });
+        socket.data.hasLeft = true;
+        socket.leave(this.roomName(session.id));
+        this.emitSessionState(session);
+        return { session };
+      });
+    });
+
+    socket.on("session:reconnect", async (payload = {}, callback) => {
+      await this.handleAction(socket, payload, callback, async () => {
+        const sessionId = payload.sessionId ?? socket.data.sessionId;
+        const userId = payload.userId ?? socket.data.userId;
+        const session = await this.collaborationService.reconnectParticipant(sessionId, userId);
+        socket.join(this.roomName(session.id));
+        socket.data.hasLeft = false;
+        this.emitSessionState(session);
+        return { session };
+      });
+    });
+
+    socket.on("session:question:propose", async (payload = {}, callback) => {
+      await this.handleAction(socket, payload, callback, async () => {
+        const sessionId = payload.sessionId ?? socket.data.sessionId;
+        const session = await this.collaborationService.proposeQuestionChange(sessionId, payload);
+        this.emitSessionState(session);
+        return { session };
+      });
+    });
+
+    socket.on("session:question:respond", async (payload = {}, callback) => {
+      await this.handleAction(socket, payload, callback, async () => {
+        const sessionId = payload.sessionId ?? socket.data.sessionId;
+        const session = await this.collaborationService.respondToQuestionChange(sessionId, payload);
+        this.emitSessionState(session);
+        return { session };
+      });
+    });
+
+    socket.on("session:end", async (payload = {}, callback) => {
+      await this.handleAction(socket, payload, callback, async () => {
+        const sessionId = payload.sessionId ?? socket.data.sessionId;
+        const session = await this.collaborationService.requestSessionEnd(sessionId, payload);
+        this.emitSessionState(session);
+        return { session };
+      });
+    });
+
+    socket.on("disconnect", async () => {
+      const { sessionId, userId, hasLeft } = socket.data ?? {};
+      if (!sessionId || !userId || hasLeft) {
+        return;
+      }
+      if (this.hasActiveSocketForUser(sessionId, userId, socket.id)) {
+        return;
+      }
+      try {
+        const session = await this.collaborationService.leaveSession(sessionId, {
+          userId,
+          reason: "disconnect",
+        });
+        this.emitSessionState(session);
+      } catch (error) {
+        if (error instanceof ApiError) {
+          this.logger.warn?.("Failed to mark disconnection", {
+            socketId: socket.id,
+            sessionId,
+            userId,
+            status: error.status,
+            message: error.message,
+          });
+        } else {
+          this.logger.error?.(error);
+        }
+      }
+    });
+  }
+
+  async handleAction(socket, payload, callback, handler) {
+    try {
+      const result = await handler(payload);
+      if (typeof callback === "function") {
+        callback({ ok: true, ...result });
+      }
+    } catch (error) {
+      const apiError =
+        error instanceof ApiError
+          ? error
+          : new ApiError(500, "An unexpected error occurred while handling the socket event.");
+      if (typeof callback === "function") {
+        callback({ ok: false, error: { status: apiError.status, message: apiError.message } });
+      }
+      if (error !== apiError) {
+        this.logger.error?.(error);
+      }
+    }
+  }
+
+  roomName(sessionId) {
+    return `session:${sessionId}`;
+  }
+
+  emitSessionState(session) {
+    if (!this.io || !session?.id) return;
+    this.io.to(this.roomName(session.id)).emit("session:state", { session });
+  }
+
+  hasActiveSocketForUser(sessionId, userId, excludeSocketId) {
+    if (!this.io) {
+      return false;
+    }
+    const room = this.io.sockets.adapter.rooms.get(this.roomName(sessionId));
+    if (!room) {
+      return false;
+    }
+    for (const socketId of room) {
+      if (socketId === excludeSocketId) continue;
+      const peer = this.io.sockets.sockets.get(socketId);
+      if (peer?.data?.userId === userId && !peer.data?.hasLeft) {
+        return true;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- bootstrap an object-oriented collaboration service application that wires Express, MongoDB, Swagger docs and Socket.IO
- add repositories, validators, services and controllers to manage sessions, editor operations, reconnection windows and mutual question changes
- expose REST and WebSocket interfaces plus updated README guidance for using the collaboration service

## Testing
- pnpm install *(fails: npm registry denied access from container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d982faf483319fa621eebc5e6fb9