### PR TITLE
Add unit tests for collaboration session service and socket manager

### DIFF
--- a/backend/services/collaboration_service/package.json
+++ b/backend/services/collaboration_service/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon index.js"
+    "dev": "nodemon index.js",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/backend/services/collaboration_service/src/services/__tests__/CollaborationSessionService.test.js
+++ b/backend/services/collaboration_service/src/services/__tests__/CollaborationSessionService.test.js
@@ -1,0 +1,192 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { CollaborationSessionService } from "../CollaborationSessionService.js";
+
+const FIXED_NOW = new Date("2024-03-01T00:00:00.000Z");
+const PAST = new Date("2024-02-28T12:00:00.000Z");
+
+function createMockFn(impl = () => undefined) {
+  const fn = (...args) => {
+    fn.calls.push(args);
+    return impl(...args);
+  };
+  fn.calls = [];
+  fn.mockImplementation = (nextImpl) => {
+    impl = nextImpl;
+  };
+  fn.mockResolvedValue = (value) => {
+    impl = () => Promise.resolve(value);
+  };
+  return fn;
+}
+
+function createSession(overrides = {}) {
+  return {
+    _id: "session-1",
+    roomId: "room-1",
+    title: null,
+    questionId: null,
+    language: "javascript",
+    codeSnapshot: "initial",
+    version: 1,
+    status: "active",
+    participants: [
+      {
+        userId: "host",
+        displayName: null,
+        connected: true,
+        joinedAt: PAST,
+        lastSeenAt: PAST,
+        disconnectedAt: null,
+        reconnectBy: null,
+        endConfirmed: false,
+      },
+    ],
+    pendingQuestionChange: null,
+    endRequests: [],
+    cursorPositions: {},
+    lastOperation: null,
+    lastConflictAt: null,
+    createdAt: PAST,
+    updatedAt: PAST,
+    ...overrides,
+  };
+}
+
+test.describe("CollaborationSessionService", () => {
+  let repository;
+  let service;
+
+  test.beforeEach(() => {
+    repository = {
+      findById: createMockFn(),
+      updateById: createMockFn(),
+      findByRoomId: createMockFn(),
+      create: createMockFn(),
+    };
+    service = new CollaborationSessionService({
+      repository,
+      timeProvider: () => new Date(FIXED_NOW),
+    });
+  });
+
+  test.it("adds a new participant when joining a session", async () => {
+    repository.findById.mockResolvedValue(createSession());
+    repository.updateById.mockImplementation(async (id, update) => {
+      assert.equal(id, "session-1");
+      assert.equal(update.set.participants.length, 2);
+      const joined = update.set.participants[1];
+      assert.equal(joined.userId, "guest");
+      assert.equal(joined.connected, true);
+      return createSession({
+        participants: update.set.participants,
+        status: update.set.status,
+        updatedAt: FIXED_NOW,
+      });
+    });
+
+    const result = await service.joinSession("session-1", { userId: "guest" });
+
+    assert.equal(repository.updateById.calls.length, 1);
+    assert.equal(result.participants.length, 2);
+    const guest = result.participants.find((p) => p.userId === "guest");
+    assert.ok(guest);
+    assert.equal(guest.connected, true);
+    assert.equal(guest.disconnectedAt, null);
+    assert.equal(new Date(guest.joinedAt).toISOString(), FIXED_NOW.toISOString());
+  });
+
+  test.it("records a conflicting operation and updates metadata", async () => {
+    repository.findById.mockResolvedValue(createSession());
+    repository.updateById.mockImplementation(async (id, update) => {
+      assert.equal(update.set.version, 2);
+      assert.deepEqual(update.set.cursorPositions.host, { line: 0, column: 4, updatedAt: FIXED_NOW });
+      assert.equal(update.set.lastOperation.conflict, true);
+      return createSession({
+        version: update.set.version,
+        codeSnapshot: update.set.codeSnapshot,
+        participants: update.set.participants,
+        cursorPositions: update.set.cursorPositions,
+        lastOperation: update.set.lastOperation,
+        lastConflictAt: update.set.lastConflictAt,
+      });
+    });
+
+    const result = await service.recordOperation("session-1", {
+      userId: "host",
+      version: 0,
+      type: "insert",
+      content: "updated",
+      range: { start: 0, end: 0 },
+      cursor: { line: 0, column: 4 },
+    });
+
+    assert.equal(repository.updateById.calls.length, 1);
+    assert.equal(result.conflict, true);
+    assert.equal(result.session.version, 2);
+    const lastOperation = result.session.lastOperation;
+    assert.ok(lastOperation);
+    assert.equal(lastOperation.userId, "host");
+    assert.equal(lastOperation.type, "insert");
+    assert.equal(lastOperation.version, 2);
+    assert.equal(lastOperation.conflict, true);
+    assert.equal(new Date(lastOperation.timestamp).toISOString(), FIXED_NOW.toISOString());
+  });
+
+  test.it("returns a lock conflict without updating the session", async () => {
+    const session = createSession();
+    repository.findById.mockResolvedValue(session);
+
+    service.locks.set("session-1", [
+      {
+        userId: "peer",
+        range: { start: 0, end: 5 },
+        expiresAt: new Date(FIXED_NOW.getTime() + 1000),
+      },
+    ]);
+
+    const result = await service.recordOperation("session-1", {
+      userId: "host",
+      version: session.version,
+      type: "insert",
+      content: "updated",
+      range: { start: 0, end: 2 },
+    });
+
+    assert.equal(repository.updateById.calls.length, 0);
+    assert.equal(result.conflict, true);
+    assert.equal(result.reason, "lock_conflict");
+    assert.equal(result.lockedBy, "peer");
+    assert.equal(result.session.id, "session-1");
+  });
+
+  test.it("marks a participant as disconnected and releases locks on leave", async () => {
+    const session = createSession();
+    repository.findById.mockResolvedValue(session);
+    repository.updateById.mockImplementation(async (id, update) => {
+      assert.equal(update.set.status, "ended");
+      const participant = update.set.participants[0];
+      assert.equal(participant.connected, false);
+      assert.ok(participant.reconnectBy instanceof Date);
+      return createSession({
+        status: update.set.status,
+        participants: update.set.participants,
+      });
+    });
+
+    service.locks.set("session-1", [
+      {
+        userId: "host",
+        range: { start: 0, end: 1 },
+        expiresAt: new Date(FIXED_NOW.getTime() + 1000),
+      },
+    ]);
+
+    const result = await service.leaveSession("session-1", { userId: "host" });
+
+    assert.equal(repository.updateById.calls.length, 1);
+    assert.equal(result.status, "ended");
+    assert.equal(result.participants[0].connected, false);
+    assert.equal(service.locks.get("session-1"), undefined);
+  });
+});

--- a/backend/services/collaboration_service/src/websocket/__tests__/CollaborationSocketManager.test.js
+++ b/backend/services/collaboration_service/src/websocket/__tests__/CollaborationSocketManager.test.js
@@ -1,0 +1,262 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { CollaborationSocketManager } from "../CollaborationSocketManager.js";
+import { ApiError } from "../../errors/ApiError.js";
+
+function createMockFn(impl = () => undefined) {
+  const fn = (...args) => {
+    fn.calls.push(args);
+    return impl(...args);
+  };
+  fn.calls = [];
+  fn.mockImplementation = (nextImpl) => {
+    impl = nextImpl;
+  };
+  fn.mockResolvedValue = (value) => {
+    impl = () => Promise.resolve(value);
+  };
+  fn.mockRejectedValue = (error) => {
+    impl = () => Promise.reject(error);
+  };
+  return fn;
+}
+
+function createMockIo() {
+  const rooms = new Map();
+  const sockets = new Map();
+  const emitted = [];
+  let connectionHandler = null;
+
+  const io = {
+    on: createMockFn((event, handler) => {
+      if (event === "connection") {
+        connectionHandler = handler;
+      }
+    }),
+    to: createMockFn((room) => ({
+      emit: (event, payload) => {
+        emitted.push({ room, event, payload });
+      },
+    })),
+    sockets: {
+      adapter: {
+        rooms,
+      },
+      sockets,
+    },
+    _emitConnection(socket) {
+      sockets.set(socket.id, socket);
+      connectionHandler?.(socket);
+    },
+    _emitted: emitted,
+  };
+
+  io.joinRoom = (room, socket) => {
+    if (!rooms.has(room)) {
+      rooms.set(room, new Set());
+    }
+    rooms.get(room).add(socket.id);
+    sockets.set(socket.id, socket);
+  };
+
+  io.leaveRoom = (room, socket) => {
+    const members = rooms.get(room);
+    if (!members) return;
+    members.delete(socket.id);
+    if (members.size === 0) {
+      rooms.delete(room);
+    }
+  };
+
+  return io;
+}
+
+function createMockSocket(io, { id = "socket-1" } = {}) {
+  const handlers = new Map();
+  const socket = {
+    id,
+    data: {},
+    rooms: new Set(),
+    on: createMockFn((event, handler) => {
+      handlers.set(event, handler);
+    }),
+    join: createMockFn(async (room) => {
+      socket.rooms.add(room);
+      io.joinRoom(room, socket);
+    }),
+    leave: createMockFn(async (room) => {
+      socket.rooms.delete(room);
+      io.leaveRoom(room, socket);
+    }),
+    emit: createMockFn(),
+    async trigger(event, payload, callback) {
+      const handler = handlers.get(event);
+      if (!handler) return;
+      return handler(payload, callback);
+    },
+  };
+
+  return socket;
+}
+
+test.describe("CollaborationSocketManager", () => {
+  let collaborationService;
+  let logger;
+  let manager;
+  let io;
+  let socket;
+
+  test.beforeEach(() => {
+    collaborationService = {
+      joinSession: createMockFn(),
+      recordOperation: createMockFn(),
+      leaveSession: createMockFn(),
+      reconnectParticipant: createMockFn(),
+      proposeQuestionChange: createMockFn(),
+      respondToQuestionChange: createMockFn(),
+      requestSessionEnd: createMockFn(),
+    };
+    logger = {
+      info: createMockFn(),
+      warn: createMockFn(),
+      error: createMockFn(),
+    };
+    manager = new CollaborationSocketManager({
+      collaborationService,
+      logger,
+    });
+    io = createMockIo();
+    manager.bind(io);
+    socket = createMockSocket(io, { id: "socket-primary" });
+    io._emitConnection(socket);
+  });
+
+  test.it("joins a session and broadcasts the updated state", async () => {
+    const session = { id: "session-1", participants: [] };
+    collaborationService.joinSession.mockResolvedValue(session);
+
+    const callback = createMockFn();
+    await socket.trigger(
+      "session:join",
+      {
+        sessionId: "session-1",
+        userId: "user-1",
+        username: "Alice",
+      },
+      callback,
+    );
+
+    assert.deepEqual(collaborationService.joinSession.calls[0], ["session-1", {
+      userId: "user-1",
+      username: "Alice",
+    }]);
+    assert.deepEqual(socket.data, {
+      sessionId: "session-1",
+      userId: "user-1",
+      username: "Alice",
+      hasLeft: false,
+    });
+    assert.ok(
+      io._emitted.some(
+        (entry) =>
+          entry.room === "session:session-1" &&
+          entry.event === "session:state" &&
+          entry.payload.session === session,
+      ),
+    );
+    assert.deepEqual(callback.calls[0], [{ ok: true, session }]);
+  });
+
+  test.it("propagates operations to the room", async () => {
+    socket.data.sessionId = "session-1";
+    socket.data.userId = "user-1";
+    const result = { session: { id: "session-1" }, conflict: false };
+    collaborationService.recordOperation.mockResolvedValue(result);
+
+    const callback = createMockFn();
+    await socket.trigger(
+      "session:operation",
+      { type: "insert", content: "code" },
+      callback,
+    );
+
+    assert.deepEqual(collaborationService.recordOperation.calls[0], ["session-1", {
+      type: "insert",
+      content: "code",
+      userId: "user-1",
+    }]);
+    assert.ok(
+      io._emitted.some(
+        (entry) =>
+          entry.room === "session:session-1" &&
+          entry.event === "session:operation" &&
+          entry.payload.session === result.session &&
+          entry.payload.conflict === false,
+      ),
+    );
+    assert.deepEqual(callback.calls[0], [{ ok: true, session: result.session, conflict: false }]);
+  });
+
+  test.it("invokes the service on disconnect when there are no other active sockets", async () => {
+    socket.data = {
+      sessionId: "session-1",
+      userId: "user-1",
+      hasLeft: false,
+    };
+    const session = { id: "session-1" };
+    collaborationService.leaveSession.mockResolvedValue(session);
+
+    await socket.trigger("disconnect");
+
+    assert.deepEqual(collaborationService.leaveSession.calls[0], ["session-1", {
+      userId: "user-1",
+      reason: "disconnect",
+    }]);
+    assert.ok(
+      io._emitted.some(
+        (entry) =>
+          entry.room === "session:session-1" &&
+          entry.event === "session:state" &&
+          entry.payload.session === session,
+      ),
+    );
+  });
+
+  test.it("does not call the service on disconnect when a peer socket is active", async () => {
+    const peer = createMockSocket(io, { id: "socket-peer" });
+    peer.data = { sessionId: "session-1", userId: "user-1", hasLeft: false };
+    io.joinRoom("session:session-1", peer);
+    io._emitConnection(peer);
+
+    socket.data = {
+      sessionId: "session-1",
+      userId: "user-1",
+      hasLeft: false,
+    };
+
+    await socket.trigger("disconnect");
+
+    assert.equal(collaborationService.leaveSession.calls.length, 0);
+  });
+
+  test.it("returns structured errors through the callback", async () => {
+    const error = new ApiError(403, "Forbidden");
+    collaborationService.joinSession.mockRejectedValue(error);
+    const callback = createMockFn();
+
+    await socket.trigger(
+      "session:join",
+      { sessionId: "session-1", userId: "user-1" },
+      callback,
+    );
+
+    assert.deepEqual(callback.calls[0], [{
+      ok: false,
+      error: {
+        status: 403,
+        message: "Forbidden",
+      },
+    }]);
+    assert.equal(logger.error.calls.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- configure the collaboration service package to run tests with the built-in node test runner
- add unit tests for CollaborationSessionService covering joins, operations, lock conflicts, and leaving
- add socket manager tests to verify session events, propagation, disconnect handling, and error reporting

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e755ea6f988331a18a45f7c12444e4